### PR TITLE
Terraform hcl2

### DIFF
--- a/source/Sashimi.Tests/HclVariableTypeIdentifierFixture.cs
+++ b/source/Sashimi.Tests/HclVariableTypeIdentifierFixture.cs
@@ -1,0 +1,26 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Sashimi.Terraform.CloudTemplates;
+
+namespace Sashimi.Terraform.Tests
+{
+    public class HclVariableTypeIdentifierFixture
+    {
+        [Test]
+        [TestCase("string", "string")]
+        [TestCase("list", "raw_list")]
+        [TestCase("list(string)", "raw_list")]
+        [TestCase("tuple", "raw_list")]
+        [TestCase("tuple(number)", "raw_list")]
+        [TestCase("set", "raw_list")]
+        [TestCase("set(any)", "raw_list")]
+        [TestCase("map", "raw_map")]
+        [TestCase("map({id = string, cidr_block = string})", "raw_map")]
+        [TestCase("object", "raw_map")]
+        [TestCase("object({id = string, cidr_block = string})", "raw_map")]
+        public void CanIdentify(string type, string expected)
+        {
+            TerraformDataTypes.MapToType(type).Should().Be(expected);
+        }
+    }
+}

--- a/source/Sashimi.Tests/TerraformValidatorFixture.cs
+++ b/source/Sashimi.Tests/TerraformValidatorFixture.cs
@@ -17,6 +17,9 @@ namespace Sashimi.Terraform.Tests
     [TestFixture]
     public class TerraformValidatorFixture
     {
+        const string HclOneVariables = "variable \"test\" {\n\ttype = \"string\"\n}\n\nvariable \"list\" {\n\ttype = \"list\"\n}\n\nvariable \"map\" {\n\ttype = \"map\"\n}";
+        const string HclTwoVariables = "variable \"test\" {\n\ttype = string\n}\n\nvariable \"list\" {\n\ttype = list\n}\n\nvariable \"map\" {\n\ttype = map\n}";
+
         TerraformValidator? validator;
         IContainer? container;
 
@@ -72,22 +75,11 @@ namespace Sashimi.Terraform.Tests
             result.IsValid.Should().BeTrue();
         }
 
-        [Test]
-        [TestCase(TerraformActionTypes.Apply)]
-        [TestCase(TerraformActionTypes.Destroy)]
-        public void Should_have_error_when_inline_template_with_invalid_inline_variables(string actionType)
+        [Test, Combinatorial]
+        public void Should_have_error_when_inline_template_with_invalid_inline_variables(
+            [Values(TerraformActionTypes.Apply, TerraformActionTypes.Destroy)] string actionType,
+            [Values(HclOneVariables, HclTwoVariables)] string template)
         {
-            var template = @"variable ""test"" {
-                type = ""string""
-            }
-
-            variable ""list"" {
-                type = ""list""
-            }
-
-            variable ""map"" {
-                type = ""map""
-            }";
             var context = new DeploymentActionValidationContext(actionType,
                                                                 new Dictionary<string, string>
                                                                 {
@@ -106,22 +98,11 @@ namespace Sashimi.Terraform.Tests
             result.Errors.Should().ContainSingle().Which.PropertyName.Should().Be("Properties");
         }
 
-        [Test]
-        [TestCase(TerraformActionTypes.Apply)]
-        [TestCase(TerraformActionTypes.Destroy)]
-        public void Should_have_no_error_when_inline_template_with_valid_inline_variables(string actionType)
+        [Test, Combinatorial]
+        public void Should_have_no_error_when_inline_template_with_valid_inline_variables(
+            [Values(TerraformActionTypes.Apply, TerraformActionTypes.Destroy)] string actionType,
+            [Values(HclOneVariables, HclTwoVariables)] string template)
         {
-            var template = @"variable ""test"" {
-                type = ""string""
-            }
-
-            variable ""list"" {
-                type = ""list""
-            }
-
-            variable ""map"" {
-                type = ""map""
-            }";
             var context = new DeploymentActionValidationContext(actionType,
                                                                 new Dictionary<string, string>
                                                                 {

--- a/source/Sashimi.Tests/TerraformVariableFileGeneratorFixture.cs
+++ b/source/Sashimi.Tests/TerraformVariableFileGeneratorFixture.cs
@@ -11,20 +11,14 @@ namespace Sashimi.Terraform.Tests
     [TestFixture]
     public class TerraformVariableFileGeneratorFixture
     {
+        const string HclOneVariables = "variable \"test\" {\n\ttype = \"string\"\n}\n\nvariable \"list\" {\n\ttype = \"list\"\n}\n\nvariable \"map\" {\n\ttype = \"map\"\n}";
+        const string HclTwoVariables = "variable \"test\" {\n\ttype = string\n}\n\nvariable \"list\" {\n\ttype = list\n}\n\nvariable \"map\" {\n\ttype = map\n}";
+
         [Test]
-        public void VerifyVariableFileGeneration()
+        [TestCase(HclOneVariables)]
+        [TestCase(HclTwoVariables)]
+        public void VerifyVariableFileGeneration(string template)
         {
-            var template = @"variable ""test"" {
-                type = ""string""
-            }
-
-            variable ""list"" {
-                type = ""list""
-            }
-
-            variable ""map"" {
-                type = ""map""
-            }";
             var metadata = new TerraformHclCloudTemplateHandler().ParseTypes(template);
             var variables = @"{""test"": ""string"", ""list"": ""[1]"", ""map"": ""{\""key\"": \""value\""}""}";
             var jsonVariables = TerraformVariableFileGenerator.ConvertStringPropsToObjects(
@@ -38,19 +32,10 @@ namespace Sashimi.Terraform.Tests
         }
 
         [Test]
-        public void VerifyVariableFileGenerationWithSubstitution()
+        [TestCase(HclOneVariables)]
+        [TestCase(HclTwoVariables)]
+        public void VerifyVariableFileGenerationWithSubstitution(string template)
         {
-            var template = @"variable ""test"" {
-                type = ""string""
-            }
-
-            variable ""list"" {
-                type = ""list""
-            }
-
-            variable ""map"" {
-                type = ""map""
-            }";
             var metadata = new TerraformHclCloudTemplateHandler().ParseTypes(template);
             var variables = @"{""test"": ""#{MyVariable}"", ""list"": ""#{MyList}"", ""map"": ""#{MyMap}""}";
             var jsonVariables = TerraformVariableFileGenerator.ConvertStringPropsToObjects(
@@ -66,19 +51,10 @@ namespace Sashimi.Terraform.Tests
         /// will eventually make up valid inputs
         /// </summary>
         [Test]
-        public void VerifyVariableFileGenerationWithSubstitution2()
+        [TestCase(HclOneVariables)]
+        [TestCase(HclTwoVariables)]
+        public void VerifyVariableFileGenerationWithSubstitution2(string template)
         {
-            var template = @"variable ""test"" {
-                type = ""string""
-            }
-
-            variable ""list"" {
-                type = ""list""
-            }
-
-            variable ""map"" {
-                type = ""map""
-            }";
             var metadata = new TerraformHclCloudTemplateHandler().ParseTypes(template);
             var variables = @"{""test"": ""#{MyVariable}"", ""list"": ""[#{MyListVariable}, 2, 3]"", ""map"": ""{\""key\"": #{MyMap}}""}";
             var jsonVariables = TerraformVariableFileGenerator.ConvertStringPropsToObjects(

--- a/source/Sashimi/CloudTemplates/TerraformDataTypes.cs
+++ b/source/Sashimi/CloudTemplates/TerraformDataTypes.cs
@@ -26,7 +26,7 @@ namespace Sashimi.Terraform.CloudTemplates
         {
             if (terraformType == null) return DefaultType;
 
-            return TypeMap.Where(kv => kv.Key.StartsWith(terraformType))
+            return TypeMap.Where(kv => terraformType.StartsWith(kv.Key))
                    .Select(kv => kv.Value)
                    .FirstOrDefault()
                 ?? DefaultType;

--- a/source/Sashimi/CloudTemplates/TerraformDataTypes.cs
+++ b/source/Sashimi/CloudTemplates/TerraformDataTypes.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Sashimi.Terraform.CloudTemplates
 {
@@ -15,13 +16,20 @@ namespace Sashimi.Terraform.CloudTemplates
         {
             { "string", "string" },
             { "list", RawList },
-            { "map", RawMap }
+            { "tuple", RawList },
+            { "set", RawList },
+            { "map", RawMap },
+            { "object", RawMap }
         };
 
-        public static string MapToType(string awsType)
+        public static string MapToType(string terraformType)
         {
-            if (awsType == null) return DefaultType;
-            return TypeMap.ContainsKey(awsType) ? TypeMap[awsType] : DefaultType;
+            if (terraformType == null) return DefaultType;
+
+            return TypeMap.Where(kv => kv.Key.StartsWith(terraformType))
+                   .Select(kv => kv.Value)
+                   .FirstOrDefault()
+                ?? DefaultType;
         }
     }
 }

--- a/source/Sashimi/CloudTemplates/TerraformHclCloudTemplateHandler.cs
+++ b/source/Sashimi/CloudTemplates/TerraformHclCloudTemplateHandler.cs
@@ -60,7 +60,7 @@ namespace Sashimi.Terraform.CloudTemplates
 
         string? GetDefaultValue(HclElement argValue)
         {
-            return argValue.Children?.FirstOrDefault(child => child.Name == "default")?.ToString(true, 0);
+            return argValue.Children?.FirstOrDefault(child => child.Name == "default")?.Value;
         }
 
         string? GetDefaultDescription(HclElement argValue)

--- a/source/Sashimi/CloudTemplates/TerraformHclCloudTemplateHandler.cs
+++ b/source/Sashimi/CloudTemplates/TerraformHclCloudTemplateHandler.cs
@@ -60,7 +60,7 @@ namespace Sashimi.Terraform.CloudTemplates
 
         string? GetDefaultValue(HclElement argValue)
         {
-            return argValue.Children?.FirstOrDefault(child => child.Name == "default")?.Value;
+            return argValue.Children?.FirstOrDefault(child => child.Name == "default")?.ToString(true, 0);
         }
 
         string? GetDefaultDescription(HclElement argValue)

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -24,7 +24,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.CoreParsers.Hcl" Version="1.0.7" />
+    <PackageReference Include="Octopus.CoreParsers.Hcl" Version="1.1.0" />     
     <PackageReference Include="Octopus.Dependencies.TerraformCLI" Version="1.0.9" />
     <PackageReference Include="Sashimi.Server.Contracts" Version="7.1.0" />
   </ItemGroup>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -24,10 +24,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.CoreParsers.Hcl" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>     
+    <PackageReference Include="Octopus.CoreParsers.Hcl" Version="1.1.1" />   
     <PackageReference Include="Octopus.Dependencies.TerraformCLI" Version="1.0.9" />
     <PackageReference Include="Sashimi.Server.Contracts" Version="7.1.0" />
   </ItemGroup>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -24,7 +24,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.CoreParsers.Hcl" Version="1.1.1" />   
+    <PackageReference Include="Octopus.CoreParsers.Hcl" Version="1.1.2" /> 
     <PackageReference Include="Octopus.Dependencies.TerraformCLI" Version="1.0.9" />
     <PackageReference Include="Sashimi.Server.Contracts" Version="7.1.0" />
   </ItemGroup>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -24,7 +24,10 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.CoreParsers.Hcl" Version="1.1.0" />     
+    <PackageReference Include="Octopus.CoreParsers.Hcl" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>     
     <PackageReference Include="Octopus.Dependencies.TerraformCLI" Version="1.0.9" />
     <PackageReference Include="Sashimi.Server.Contracts" Version="7.1.0" />
   </ItemGroup>


### PR DESCRIPTION
This PR updates the Terraform library with the new HCL parsing library with HCL2 support.

The main change here is that HCL2 has richer types, requiring slightly different matching logic.