### PR TITLE
Copy Octopus.Dependencies as lower case for unix systems

### DIFF
--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -32,6 +32,8 @@
   <Target Name="GetPackageFiles" AfterTargets="ResolveReferences" DependsOnTargets="RunResolvePackageDependencies">
     <Message Text="Collecting nupkg packages to bundle with Sashimi module binaries" />
     <ItemGroup>
+      <!-- We ".ToLower()" on the Pacakge Definition names here as packages are downloaded with lower case, but this is using the 
+      Include name which is camel case, so we want to make sure we lower case it so it can find the path correctly on unix systems --> 
       <Content Include="@(PackageDefinitions->'%(ResolvedPath)/$([System.String]::new('%(Name)').ToLower()).%(Version).nupkg')" Condition="$([System.String]::new('%(Name)').ToLower().Contains('octopus.dependencies'))">
         <Visible>false</Visible>
         <Link>@(PackageDefinitions->'%(Name).nupkg')</Link>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -34,11 +34,11 @@
     <ItemGroup>
       <Content Include="@(PackageDefinitions->'%(ResolvedPath)/$([System.String]::new('%(Name)').ToLower()).%(Version).nupkg')" Condition="$([System.String]::new('%(Name)').ToLower().Contains('octopus.dependencies'))">
         <Visible>false</Visible>
-        <Link>@(PackageDefinitions->'$([System.String]::new('%(Name)').ToLower()).nupkg')</Link>
+        <Link>@(PackageDefinitions->'%(Name).nupkg')</Link>
         <Pack>true</Pack>
         <PackageCopyToOutput>true</PackageCopyToOutput>
         <PackageFlatten>true</PackageFlatten>
-        <PackagePath>@(PackageDefinitions->'contentFiles/any/any/$([System.String]::new('%(Name)').ToLower()).nupkg')</PackagePath>
+        <PackagePath>@(PackageDefinitions->'contentFiles/any/any/%(Name).nupkg')</PackagePath>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
     </ItemGroup>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -24,7 +24,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.CoreParsers.Hcl" Version="1.1.2" /> 
+    <PackageReference Include="Octopus.CoreParsers.Hcl" Version="1.1.2" />
     <PackageReference Include="Octopus.Dependencies.TerraformCLI" Version="1.0.9" />
     <PackageReference Include="Sashimi.Server.Contracts" Version="7.1.0" />
   </ItemGroup>
@@ -32,13 +32,13 @@
   <Target Name="GetPackageFiles" AfterTargets="ResolveReferences" DependsOnTargets="RunResolvePackageDependencies">
     <Message Text="Collecting nupkg packages to bundle with Sashimi module binaries" />
     <ItemGroup>
-      <Content Include="@(PackageDefinitions->'%(ResolvedPath)/%(Name).%(Version).nupkg')" Condition="$([System.String]::new('%(Name)').ToLower().Contains('octopus.dependencies'))">
+      <Content Include="@(PackageDefinitions->'%(ResolvedPath)/$([System.String]::new('%(Name)').ToLower()).%(Version).nupkg')" Condition="$([System.String]::new('%(Name)').ToLower().Contains('octopus.dependencies'))">
         <Visible>false</Visible>
-        <Link>@(PackageDefinitions->'%(Name).nupkg')</Link>
+        <Link>@(PackageDefinitions->'$([System.String]::new('%(Name)').ToLower()).nupkg')</Link>
         <Pack>true</Pack>
         <PackageCopyToOutput>true</PackageCopyToOutput>
         <PackageFlatten>true</PackageFlatten>
-        <PackagePath>@(PackageDefinitions->'contentFiles/any/any/%(Name).nupkg')</PackagePath>
+        <PackagePath>@(PackageDefinitions->'contentFiles/any/any/$([System.String]::new('%(Name)').ToLower()).nupkg')</PackagePath>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
     </ItemGroup>


### PR DESCRIPTION
The Content Include in the csproj for Sashimi copies any Package Definition with `Octopus.Dependencies` in it. `dotnet restore` restores the packages in lowercase as seen below: 

![image](https://user-images.githubusercontent.com/8922465/103978109-726c3280-51c6-11eb-97a1-b86723916d98.png)

Without lowercasing the file names in this PR, it wasn't able to build on linux due to the following error:

`  Microsoft.Common.CurrentVersion.targets(4651, 5): [MSB3030] Could not copy the file "/home/corey/.nuget/packages/octopus.dependencies.terraformcli/1.0.9/Octopus.Dependencies.TerraformCLI.1.0.9.nupkg" because it was not found.`