### PR TITLE
Batch of fixes for Sashimi.Terraform targetting Server 2020.5

### DIFF
--- a/source/Calamari/App.config
+++ b/source/Calamari/App.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<configuration>
+    <runtime>
+        <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
+    </runtime>
+</configuration>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -17,8 +17,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.4.34" />
-    <PackageReference Include="Calamari.CloudAccounts" Version="14.8.1" />
-    <PackageReference Include="Calamari.Common" Version="14.11.2" />
+    <PackageReference Include="Calamari.CloudAccounts" Version="15.1.6" />
+    <PackageReference Include="Calamari.Common" Version="15.1.6" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Extensibility.Tests" Version="10.0.1" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="7.1.0" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="8.5.4" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.22" />
   </ItemGroup>
 

--- a/source/Sashimi.Tests/TerraformValidatorFixture.cs
+++ b/source/Sashimi.Tests/TerraformValidatorFixture.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using FluentValidation.TestHelper;
 using NUnit.Framework;
 using Octopus.Server.Extensibility.HostServices.Model;
+using Octopus.Server.Extensibility.HostServices.Model.Feeds;
 using Sashimi.Server.Contracts;
 using Sashimi.Server.Contracts.ActionHandlers.Validation;
 using Sashimi.Server.Contracts.CloudTemplates;
@@ -148,7 +149,7 @@ namespace Sashimi.Terraform.Tests
                                                                 {
                                                                     { KnownVariables.Action.Script.ScriptSource, KnownVariableValues.Action.Script.ScriptSource.Package }
                                                                 },
-                                                                new List<PackageReference> { new PackageReference("packageId", "feedId") });
+                                                                new List<PackageReference> { new PackageReference("packageId", new FeedIdOrName("feedId")) });
 
             var result = validator.TestValidate(context);
 

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <PackageReference Include="Octopus.CoreParsers.Hcl" Version="1.1.2" />
     <PackageReference Include="Octopus.Dependencies.TerraformCLI" Version="1.0.9" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="7.1.0" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="8.5.4" />
   </ItemGroup>
 
   <Target Name="GetPackageFiles" AfterTargets="ResolveReferences" DependsOnTargets="RunResolvePackageDependencies">
@@ -34,7 +34,7 @@
     <ItemGroup>
       <!-- We ".ToLower()" on the Pacakge Definition names here as packages are downloaded with lower case, but this is using the 
       Include name which is camel case, so we want to make sure we lower case it so it can find the path correctly on unix systems --> 
-      <Content Include="@(PackageDefinitions->'%(ResolvedPath)/$([System.String]::new('%(Name)').ToLower()).%(Version).nupkg')" Condition="$([System.String]::new('%(Name)').ToLower().Contains('octopus.dependencies'))">
+      <Content Include="@(PackageDefinitions-&gt;'%(ResolvedPath)/$([System.String]::new('%(Name)').ToLower()).%(Version).nupkg')" Condition="$([System.String]::new('%(Name)').ToLower().Contains('octopus.dependencies'))">
         <Visible>false</Visible>
         <Link>@(PackageDefinitions->'%(Name).nupkg')</Link>
         <Pack>true</Pack>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -34,7 +34,7 @@
     <ItemGroup>
       <!-- We ".ToLower()" on the Pacakge Definition names here as packages are downloaded with lower case, but this is using the 
       Include name which is camel case, so we want to make sure we lower case it so it can find the path correctly on unix systems --> 
-      <Content Include="@(PackageDefinitions-&gt;'%(ResolvedPath)/$([System.String]::new('%(Name)').ToLower()).%(Version).nupkg')" Condition="$([System.String]::new('%(Name)').ToLower().Contains('octopus.dependencies'))">
+      <Content Include="@(PackageDefinitions->'%(ResolvedPath)/$([System.String]::new('%(Name)').ToLower()).%(Version).nupkg')" Condition="$([System.String]::new('%(Name)').ToLower().Contains('octopus.dependencies'))">
         <Visible>false</Visible>
         <Link>@(PackageDefinitions->'%(Name).nupkg')</Link>
         <Pack>true</Pack>


### PR DESCRIPTION
Fixes both:
- https://github.com/OctopusDeploy/Issues/issues/6683
- https://github.com/OctopusDeploy/Issues/issues/6778

For netfull we need to explicitly enable long file paths in the config file.
Update references to Calamari + Sashimi to match what the Server is referencing