### PR TITLE
Update references to Calamari + Sashimi to match what Server 2020.6 is referencing

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -14,9 +14,9 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="nunit" Version="3.12.0" />
+        <PackageReference Include="nunit" Version="3.13.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.22" />
         <PackageReference Include="NSubstitute" Version="4.2.2" />
         <PackageReference Include="Shouldly" Version="2.8.2" />

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -16,8 +16,8 @@
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="nunit" Version="3.13.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-        <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.22" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+        <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
         <PackageReference Include="NSubstitute" Version="4.2.2" />
         <PackageReference Include="Shouldly" Version="2.8.2" />
     </ItemGroup>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -17,8 +17,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.4.34" />
-    <PackageReference Include="Calamari.CloudAccounts" Version="15.1.6" />
-    <PackageReference Include="Calamari.Common" Version="15.1.6" />
+    <PackageReference Include="Calamari.CloudAccounts" Version="17.0.1" />
+    <PackageReference Include="Calamari.Common" Version="17.0.1" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -14,10 +14,10 @@
     <ProjectReference Include="..\Calamari\Calamari.csproj" />
     <ProjectReference Include="..\Sashimi\Sashimi.csproj" />
     <PackageReference Include="Assent" Version="1.6.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Extensibility.Tests" Version="10.0.1" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="8.5.4" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="8.6.4" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.22" />
   </ItemGroup>
 

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -14,11 +14,11 @@
     <ProjectReference Include="..\Calamari\Calamari.csproj" />
     <ProjectReference Include="..\Sashimi\Sashimi.csproj" />
     <PackageReference Include="Assent" Version="1.6.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Extensibility.Tests" Version="10.0.1" />
     <PackageReference Include="Sashimi.Tests.Shared" Version="8.6.4" />
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.22" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Sashimi/ActionHandler/TerraformVariableFileGenerator.cs
+++ b/source/Sashimi/ActionHandler/TerraformVariableFileGenerator.cs
@@ -14,7 +14,7 @@ namespace Sashimi.Terraform.ActionHandler
         /// <summary>
         /// When variables are supplied from the UI (i.e. not from a package), all values are strings.
         /// So maps and lists are just strings, even though they should be objects.
-        /// 
+        ///
         /// This method find variables that should be objects, and parses the strings sent in
         /// into real objects.
         /// </summary>
@@ -45,7 +45,7 @@ namespace Sashimi.Terraform.ActionHandler
         {
             var properties = GetPropertiesAsList(parsedProperties, metadata, GetHclVariableValue);
             var asStr = string.Join("\n", properties);
-            return variableDictionary.EvaluateIgnoringErrors(asStr);
+            return variableDictionary.EvaluateIgnoringErrors(asStr)!;
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Sashimi.Terraform.ActionHandler
         {
             var properties = GetPropertiesAsList(parsedProperties, metadata, GetJsonVariableValue);
             var asJson = "{" + string.Join(",", properties) + "}";
-            return variableDictionary.EvaluateIgnoringErrors(asJson);
+            return variableDictionary.EvaluateIgnoringErrors(asJson)!;
         }
 
         static List<string> GetPropertiesAsList(JObject parsedProperties, Metadata metadata, Func<string?, JProperty, string> getVariableValue)

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Sashimi.Terraform</AssemblyName>
@@ -26,7 +26,7 @@
   <ItemGroup>
     <PackageReference Include="Octopus.CoreParsers.Hcl" Version="1.1.2" />
     <PackageReference Include="Octopus.Dependencies.TerraformCLI" Version="1.0.9" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="8.5.4" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="8.6.4" />
   </ItemGroup>
 
   <Target Name="GetPackageFiles" AfterTargets="ResolveReferences" DependsOnTargets="RunResolvePackageDependencies">


### PR DESCRIPTION
This PR completes the work started in https://github.com/OctopusDeploy/Sashimi.Terraform/pull/16

This ensures the versions referenced in Server 2020.6 for both Calamari And Sashimi packages match the Sashimi flavour package.