### PR TITLE
Upgrade to nuke 5.1.0

### DIFF
--- a/.nuke
+++ b/.nuke
@@ -1,1 +1,0 @@
-source/Terraform.sln

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Build Schema",
+  "$ref": "#/definitions/build",
+  "definitions": {
+    "build": {
+      "type": "object",
+      "properties": {
+        "Configuration": {
+          "type": "string",
+          "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
+          "enum": [
+            "Debug",
+            "Release"
+          ]
+        },
+        "Continue": {
+          "type": "boolean",
+          "description": "Indicates to continue a previously failed build attempt"
+        },
+        "Help": {
+          "type": "boolean",
+          "description": "Shows the help text for this build assembly"
+        },
+        "Host": {
+          "type": "string",
+          "description": "Host for execution. Default is 'automatic'",
+          "enum": [
+            "AppVeyor",
+            "AzurePipelines",
+            "Bamboo",
+            "Bitrise",
+            "GitHubActions",
+            "GitLab",
+            "Jenkins",
+            "SpaceAutomation",
+            "TeamCity",
+            "Terminal",
+            "TravisCI"
+          ]
+        },
+        "InternalNugetFeedApiKey": {
+          "type": "string",
+          "description": "Internal Nuget Feed URL ApiKey"
+        },
+        "InternalNugetFeedUrl": {
+          "type": "string",
+          "description": "Internal Nuget Feed URL"
+        },
+        "NoLogo": {
+          "type": "boolean",
+          "description": "Disables displaying the NUKE logo"
+        },
+        "Plan": {
+          "type": "boolean",
+          "description": "Shows the execution plan (HTML)"
+        },
+        "Profile": {
+          "type": "array",
+          "description": "Defines the profiles to load",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Root": {
+          "type": "string",
+          "description": "Root directory during build execution"
+        },
+        "Skip": {
+          "type": "array",
+          "description": "List of targets to be skipped. Empty list skips all dependencies",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Clean",
+              "Compile",
+              "CopyToLocalPackages",
+              "Default",
+              "PackSashimi",
+              "Publish",
+              "PublishCalamariProjects",
+              "PublishSashimiTestProjects",
+              "Restore",
+              "Test"
+            ]
+          }
+        },
+        "Solution": {
+          "type": "string",
+          "description": "Path to a solution file that is automatically loaded"
+        },
+        "Target": {
+          "type": "array",
+          "description": "List of targets to be invoked. Default is '{default_target}'",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Clean",
+              "Compile",
+              "CopyToLocalPackages",
+              "Default",
+              "PackSashimi",
+              "Publish",
+              "PublishCalamariProjects",
+              "PublishSashimiTestProjects",
+              "Restore",
+              "Test"
+            ]
+          }
+        },
+        "Verbosity": {
+          "type": "string",
+          "description": "Logging verbosity during build execution. Default is 'Normal'",
+          "enum": [
+            "Minimal",
+            "Normal",
+            "Quiet",
+            "Verbose"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/.nuke/parameters.json
+++ b/.nuke/parameters.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./build.schema.json",
+  "Solution": "source/Terraform.sln"
+}

--- a/build.cmd
+++ b/build.cmd
@@ -4,4 +4,4 @@
 :; exit $?
 
 @ECHO OFF
-powershell -ExecutionPolicy ByPass -NoProfile %0\..\build.ps1 %*
+powershell -ExecutionPolicy ByPass -NoProfile "%~dp0build.ps1" %*

--- a/build.ps1
+++ b/build.ps1
@@ -14,7 +14,7 @@ $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 ###########################################################################
 
 $BuildProjectFile = "$PSScriptRoot\build\_build.csproj"
-$TempDirectory = "$PSScriptRoot\\.tmp"
+$TempDirectory = "$PSScriptRoot\\.nuke\temp"
 
 $DotNetGlobalFile = "$PSScriptRoot\\global.json"
 $DotNetInstallUrl = "https://dot.net/v1/dotnet-install.ps1"

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 ###########################################################################
 
 BUILD_PROJECT_FILE="$SCRIPT_DIR/build/_build.csproj"
-TEMP_DIRECTORY="$SCRIPT_DIR//.tmp"
+TEMP_DIRECTORY="$SCRIPT_DIR//.nuke/temp"
 
 DOTNET_GLOBAL_FILE="$SCRIPT_DIR//global.json"
 DOTNET_INSTALL_URL="https://dot.net/v1/dotnet-install.sh"

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -23,7 +23,7 @@ class Build : NukeBuild
     ///   - Microsoft VisualStudio     https://nuke.build/visualstudio
     ///   - Microsoft VSCode           https://nuke.build/vscode
 
-    public static int Main () => Execute<Build>(x => x.Default);
+    public static int Main () => Execute<Build>(x => x.PackSashimi);
 
     [Parameter("Configuration to build - Default is 'Debug' (local) or 'Release' (server)")]
     readonly Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;
@@ -170,9 +170,10 @@ class Build : NukeBuild
             ArtifactsDirectory.GlobFiles("*symbols*").ForEach(DeleteFile);
         });
 
+    // ReSharper disable once UnusedMember.Local - it is actually used (see TriggeredBy)
     Target CopyToLocalPackages => _ => _
         .DependsOn(Test)
-        .DependsOn(PackSashimi)
+        .TriggeredBy(PackSashimi)
         .Unlisted()
         .OnlyWhenStatic(() => IsLocalBuild)
         .Executes(() =>
@@ -196,7 +197,4 @@ class Build : NukeBuild
                 .SetTimeout(1200)
             );
     });
-
-    Target Default => _ => _
-        .DependsOn(CopyToLocalPackages);
 }

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2020.3.0" />
-    <PackageReference Include="Nuke.Common" Version="5.0.2" />
+    <PackageReference Include="Nuke.Common" Version="5.1.0" />
     <PackageDownload Include="GitVersion.Tool" Version="[5.1.1]" />
   </ItemGroup>
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
-    "sdk": {
-        "version": "3.1.404",
-        "rollForward": "latestFeature"
-    }
+  "sdk": {
+    "version": "5.0.104",
+    "rollForward": "latestFeature"
+  }
 }

--- a/source/Sashimi/CloudTemplates/TerraformHclCloudTemplateHandler.cs
+++ b/source/Sashimi/CloudTemplates/TerraformHclCloudTemplateHandler.cs
@@ -49,13 +49,11 @@ namespace Sashimi.Terraform.CloudTemplates
         public object ParseModel(string template)
         {
             var parameters = GetVariables(template);
-            return parameters?
-                   .Select(x => new KeyValuePair<string, object?>(
-                                                                  x.Value,
-                                                                  GetDefaultValue(x))
-                          )
-                   .ToDictionary(x => x.Key, x => x.Value)
-                   ?? new Dictionary<string, object?>();
+
+            if (parameters != null)
+                return parameters.Select(x => new KeyValuePair<string, object?>(x.Value, GetDefaultValue(x)))
+                                 .ToDictionary(x => x.Key, x => x.Value);
+            return new Dictionary<string, object?>();
         }
 
         string? GetDefaultValue(HclElement argValue)
@@ -97,7 +95,7 @@ namespace Sashimi.Terraform.CloudTemplates
             return "string";
         }
 
-        static IList<HclElement> GetVariables(string template)
+        static IList<HclElement>? GetVariables(string template)
         {
             if (template == null) return new List<HclElement>();
 


### PR DESCRIPTION
We [upgraded](https://github.com/OctopusDeploy/tool-containers/pull/25) the base build image to install the latest nuke.globaltool (version 5.1.0).
Nuke 5.1.0 [includes a new version](https://github.com/nuke-build/nuke/commit/bef28aab33d202688f67f527f7692b360ba93fa4) of GitVersion.Tool.
This meant we [had to update](https://github.com/OctopusDeploy/tool-containers/pull/25/files#diff-3dc3767944d5097e69dbc20d45548730bb43dfdbde1be7edfdb4140a66c6cfa1R58) the path (LD_LIBRARY_PATH) to the new native tool binaries.
Unfortunately this meant that while new stuff will build, old stuff will not.

As a quick fix, we are updating all projects to nuke 5.1.0 while we ponder the proper fix.

This should have no impact to the builds - if any, it'll be to take it from broken to 💚 