### PR TITLE
Add support for Terraform v0.15.0

### DIFF
--- a/source/Calamari.Tests/TerraformCliExecutorFixture.cs
+++ b/source/Calamari.Tests/TerraformCliExecutorFixture.cs
@@ -21,7 +21,8 @@ namespace Calamari.Terraform.Tests
         {
             variables = Substitute.For<IVariables>();
             var commandLineRunner = Substitute.For<ICommandLineRunner>();
-            commandLineRunner.Execute(Arg.Any<CommandLineInvocation>()).Returns(new CommandResult("foo", 0));
+            commandLineRunner.Execute(Arg.Do<CommandLineInvocation>(invocation => invocation.AdditionalInvocationOutputSink.WriteInfo("Terraform v0.15.0")))
+                             .Returns(new CommandResult("foo", 0));
             cliExecutor = new TerraformCliExecutor(Substitute.For<ILog>(),
                                                    Substitute.For<ICalamariFileSystem>(),
                                                    commandLineRunner,

--- a/source/Calamari/Behaviours/DestroyBehaviour.cs
+++ b/source/Calamari/Behaviours/DestroyBehaviour.cs
@@ -31,7 +31,7 @@ namespace Calamari.Terraform.Behaviours
                                                       environmentVariables))
             {
                 cli.ExecuteCommand("destroy",
-                                   "-force",
+                                   "-auto-approve",
                                    "-no-color",
                                    cli.TerraformVariableFiles,
                                    cli.ActionParams)

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -23,5 +23,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="NuGet.Versioning" Version="5.9.1" />
   </ItemGroup>
 </Project>

--- a/source/Calamari/Helpers/VersionExtensions.cs
+++ b/source/Calamari/Helpers/VersionExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace Calamari.Terraform.Helpers
+{
+    public static class VersionExtensions
+    {
+        public static bool IsLessThan(this Version value, string compareTo)
+        {
+            return value.CompareTo(new Version(compareTo)) < 0;
+        }
+    }
+}

--- a/source/Calamari/TerraformCliExecutor.cs
+++ b/source/Calamari/TerraformCliExecutor.cs
@@ -175,7 +175,8 @@ namespace Calamari.Terraform
                 .VerifySuccess();
 
             version = version.Replace("Terraform v", "");
-            version = version.Substring(0, version.IndexOf('\n'));
+            if (version.IndexOf('\n') != -1)
+                version = version.Substring(0, version.IndexOf('\n'));
             
             return new Version(version);
         }

--- a/source/Calamari/TerraformCliExecutor.cs
+++ b/source/Calamari/TerraformCliExecutor.cs
@@ -31,7 +31,7 @@ namespace Calamari.Terraform
         Dictionary<string, string> defaultEnvironmentVariables;
         readonly Version version;
 
-        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.8"), true, NuGetVersion.Parse("0.15.0"), true);
+        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.8"), true, NuGetVersion.Parse("0.15"), true);
 
         public TerraformCliExecutor(
             ILog log,

--- a/source/Sashimi.Tests/ActionHandlersFixture.cs
+++ b/source/Sashimi.Tests/ActionHandlersFixture.cs
@@ -502,6 +502,8 @@ namespace Sashimi.Terraform.Tests
         [Test]
         public void InlineHclTemplateAndVariables()
         {
+            IgnoreIfVersionIsNotInRange("0.11.8", "0.15.0");
+            
             const string variables =
                 "{\"stringvar\":\"default string\",\"images\":\"\",\"test2\":\"\",\"test3\":\"\",\"test4\":\"\"}";
             const string template = @"variable stringvar {
@@ -531,6 +533,71 @@ variable ""test3"" {
 }
 variable ""test4"" {
   type    = ""map""
+  default = {
+    val1 = {
+      val2 = [""hi""]
+    }                        
+  }
+}
+# Example of getting an element from a list in a map
+output ""nestedlist"" {
+  value = ""${element(var.test2[""val1""], 0)}""
+}
+# Example of getting an element from a nested map
+output ""nestedmap"" {
+  value = ""${lookup(var.test3[""val1""], ""val2"")}""
+}";
+
+            ExecuteAndReturnLogOutput<TerraformApplyActionHandler>(_ =>
+                                                                   {
+                                                                       _.Variables.Add("RandomNumber", new Random().Next().ToString());
+                                                                       _.Variables.Add(TerraformSpecialVariables.Action.Terraform.Template, template);
+                                                                       _.Variables.Add(TerraformSpecialVariables.Action.Terraform.TemplateParameters, variables);
+                                                                       _.Variables.Add(KnownVariables.Action.Script.ScriptSource,
+                                                                                       KnownVariables.Action.Script.ScriptSourceOptions.Inline);
+                                                                   },
+                                                                   String.Empty,
+                                                                   _ =>
+                                                                   {
+                                                                       _.OutputVariables.ContainsKey("TerraformValueOutputs[nestedlist]").Should().BeTrue();
+                                                                       _.OutputVariables.ContainsKey("TerraformValueOutputs[nestedmap]").Should().BeTrue();
+                                                                   });
+        }
+        
+        [Test]
+        public void InlineHclTemplateAndVariablesV015()
+        {
+            IgnoreIfVersionIsNotInRange("0.15.0");
+                
+            const string variables =
+                "{\"stringvar\":\"default string\",\"images\":\"\",\"test2\":\"\",\"test3\":\"\",\"test4\":\"\"}";
+            const string template = @"variable stringvar {
+  type = string
+  default = ""default string""
+}
+variable ""images"" {
+  type = map(string)
+  default = {
+    us-east-1 = ""image-1234""
+    us-west-2 = ""image-4567""
+  }
+}
+variable ""test2"" {
+  type    = map
+  default = {
+    val1 = [""hi""]
+  }
+}
+variable ""test3"" {
+  type    = map
+  default = {
+    val1 = {
+      val2 = ""#{RandomNumber}""
+    }
+  }
+}
+variable ""test4"" {
+  type    = map
   default = {
     val1 = {
       val2 = [""hi""]
@@ -600,14 +667,16 @@ output ""config-map-aws-auth"" {{
                                                                    {
                                                                        _.OutputVariables.ContainsKey("TerraformValueOutputs[config-map-aws-auth]").Should().BeTrue();
                                                                        _.OutputVariables["TerraformValueOutputs[config-map-aws-auth]"]
-                                                                        .Value?.TrimEnd().Should()
+                                                                        .Value?.TrimEnd().Replace("\r\n", "\n").Should()
                                                                         .Be($"{expected.Replace("\r\n", "\n")}");
                                                                    });
         }
-
+        
         [Test]
         public void InlineJsonTemplateAndVariables()
         {
+            IgnoreIfVersionIsNotInRange("0.11.8", "0.15.0");
+            
             const string variables =
                 "{\"ami\":\"new ami value\"}";
             const string template = @"{
@@ -630,6 +699,63 @@ output ""config-map-aws-auth"" {{
       },
       ""test3"":{
          ""value"":""${map(\""a\"", \""hi\"")}""
+      },
+      ""ami"":{
+         ""value"":""${var.ami}""
+      },
+      ""random"":{
+         ""value"":""#{RandomNumber}""
+      }
+    }
+}";
+
+            var randomNumber = new Random().Next().ToString();
+
+            ExecuteAndReturnLogOutput<TerraformApplyActionHandler>(_ =>
+                                                                   {
+                                                                       _.Variables.Add("RandomNumber", randomNumber);
+                                                                       _.Variables.Add(TerraformSpecialVariables.Action.Terraform.Template, template);
+                                                                       _.Variables.Add(TerraformSpecialVariables.Action.Terraform.TemplateParameters, variables);
+                                                                       _.Variables.Add(KnownVariables.Action.Script.ScriptSource,
+                                                                                       KnownVariables.Action.Script.ScriptSourceOptions.Inline);
+                                                                   },
+                                                                   String.Empty,
+                                                                   _ =>
+                                                                   {
+                                                                       _.OutputVariables.ContainsKey("TerraformValueOutputs[ami]").Should().BeTrue();
+                                                                       _.OutputVariables["TerraformValueOutputs[ami]"].Value.Should().Be("new ami value");
+                                                                       _.OutputVariables.ContainsKey("TerraformValueOutputs[random]").Should().BeTrue();
+                                                                       _.OutputVariables["TerraformValueOutputs[random]"].Value.Should().Be(randomNumber);
+                                                                   });
+        }
+        
+        [Test]
+        public void InlineJsonTemplateAndVariablesV015()
+        {
+            IgnoreIfVersionIsNotInRange("0.15.0");
+            
+            const string variables =
+                "{\"ami\":\"new ami value\"}";
+            const string template = @"{
+    ""variable"":{
+      ""ami"":{
+         ""type"":""string"",
+         ""description"":""the AMI to use"",
+         ""default"":""1234567890""
+      }
+    },
+    ""output"":{
+      ""test"":{
+         ""value"":""hi there""
+      },
+      ""test2"":{
+         ""value"":[
+            ""hi there"",
+            ""hi again""
+         ]
+      },
+      ""test3"":{
+         ""value"":""${tomap({ a = \""hi\"" })}""
       },
       ""ami"":{
          ""value"":""${var.ami}""

--- a/source/Sashimi.Tests/ActionHandlersFixture.cs
+++ b/source/Sashimi.Tests/ActionHandlersFixture.cs
@@ -450,7 +450,7 @@ namespace Sashimi.Terraform.Tests
                 _.Variables.Add("Octopus.Action.Aws.Region", "ap-southeast-1");
                 _.Variables.Add("Hello", "Hello World from AWS");
                 _.Variables.Add("bucket_name", bucketName);
-                _.Variables.Add(TerraformSpecialVariables.Action.Terraform.VarFiles, "example.tfvars"); // TODO: replace file with the original after substitution
+                _.Variables.Add(TerraformSpecialVariables.Action.Terraform.VarFiles, "example.tfvars");
                 _.Variables.Add(TerraformSpecialVariables.Action.Terraform.AWSManagedAccount, "AWS");
                 _.Variables.Add(KnownVariables.OriginalPackageDirectoryPath, temporaryFolder.DirectoryPath);
             }


### PR DESCRIPTION
Fixes https://github.com/OctopusDeploy/Issues/issues/6835

This is intended to be an interim fix to accommodate two versions of Terraform - the one shipped with Calamari (0.11.8) and the latest (0.15.0). 

Integration tests run separately for each version, with the exception of the few tests that only apply to one of the versions.

We will review current behavior in one of the next few releases to possibly allow `init` and `apply` parameters to be overridden entirely.