### PR TITLE
Pass environment variables to CLI executor

### DIFF
--- a/source/Calamari/Behaviours/TerraformDeployBehaviour.cs
+++ b/source/Calamari/Behaviours/TerraformDeployBehaviour.cs
@@ -7,6 +7,7 @@ using Calamari.Common.Plumbing.Extensions;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Pipeline;
 using Calamari.Common.Plumbing.Variables;
+using Newtonsoft.Json;
 
 namespace Calamari.Terraform.Behaviours
 {
@@ -40,7 +41,18 @@ namespace Calamari.Terraform.Behaviours
             if (useAzureAccount)
                 environmentVariables.AddRange(AzureEnvironmentVariables(variables));
 
+            environmentVariables.AddRange(GetEnvironmentVariableArgs(context.Variables));
+
             await Execute(context, environmentVariables);
+        }
+
+        static Dictionary<string, string> GetEnvironmentVariableArgs(IVariables variables)
+        {
+            var rawJson = variables.Get(TerraformSpecialVariables.Action.Terraform.EnvironmentVariables);
+            if (string.IsNullOrEmpty(rawJson))
+                return new Dictionary<string, string>();
+
+            return JsonConvert.DeserializeObject<Dictionary<string, string>>(rawJson);
         }
         
         protected abstract Task Execute(RunningDeployment deployment, Dictionary<string, string> environmentVariables);

--- a/source/Calamari/TerraformSpecialVariables.cs
+++ b/source/Calamari/TerraformSpecialVariables.cs
@@ -23,6 +23,7 @@ namespace Calamari.Terraform
                 public const string VarFiles = "Octopus.Action.Terraform.VarFiles";
                 public const string PlanOutput = "TerraformPlanOutput";
                 public const string PlanDetailedExitCode = "TerraformPlanDetailedExitCode";
+                public const string EnvironmentVariables = "Octopus.Action.Terraform.EnvVariables";
             }
         }
     }

--- a/source/Sashimi.Tests/CommonTemplates/HclWithVariablesV0118.hcl
+++ b/source/Sashimi.Tests/CommonTemplates/HclWithVariablesV0118.hcl
@@ -1,0 +1,43 @@
+variable stringvar {
+  type = "string"
+  default = "default string"
+}
+variable "images" {
+  type = "map"
+  default = {
+    us-east-1 = "image-1234"
+    us-west-2 = "image-4567"
+  }
+}
+variable "test2" {
+  type = "map"
+  default = {
+    val1 = [
+      "hi"]
+  }
+}
+variable "test3" {
+  type = "map"
+  default = {
+    val1 = {
+      val2 = "#{RandomNumber}"
+    }
+  }
+}
+variable "test4" {
+  type = "map"
+  default = {
+    val1 = {
+      val2 = [
+        "hi"]
+    }
+  }
+}
+# Example of getting an element from a list in a map
+output "nestedlist" {
+  value = "${element(var.test2["val1"], 0)}"
+}
+# Example of getting an element from a nested map
+output "nestedmap" {
+  value = "${lookup(var.test3["val1"], "val2")}"
+}

--- a/source/Sashimi.Tests/CommonTemplates/HclWithVariablesV0150.hcl
+++ b/source/Sashimi.Tests/CommonTemplates/HclWithVariablesV0150.hcl
@@ -1,0 +1,43 @@
+﻿variable stringvar {
+  type = string
+  default = "default string"
+}
+variable "images" {
+  type = map(string)
+  default = {
+    us-east-1 = "image-1234"
+    us-west-2 = "image-4567"
+  }
+}
+variable "test2" {
+  type = map
+  default = {
+    val1 = [
+      "hi"]
+  }
+}
+variable "test3" {
+  type = map
+  default = {
+    val1 = {
+      val2 = "#{RandomNumber}"
+    }
+  }
+}
+variable "test4" {
+  type = map
+  default = {
+    val1 = {
+      val2 = [
+        "hi"]
+    }
+  }
+}
+# Example of getting an element from a list in a map
+output "nestedlist" {
+  value = "${element(var.test2["val1"], 0)}"
+}
+# Example of getting an element from a nested map
+output "nestedmap" {
+  value = "${lookup(var.test3["val1"], "val2")}"
+}

--- a/source/Sashimi.Tests/CommonTemplates/InlineJsonWithVariablesV01180.json
+++ b/source/Sashimi.Tests/CommonTemplates/InlineJsonWithVariablesV01180.json
@@ -1,0 +1,29 @@
+﻿{
+  "variable": {
+    "ami": {
+      "type": "string",
+      "description": "the AMI to use",
+      "default": "1234567890"
+    }
+  },
+  "output": {
+    "test": {
+      "value": "hi there"
+    },
+    "test2": {
+      "value": [
+        "hi there",
+        "hi again"
+      ]
+    },
+    "test3": {
+      "value": "${map(\"a\", \"hi\")}"
+    },
+    "ami": {
+      "value": "${var.ami}"
+    },
+    "random": {
+      "value": "#{RandomNumber}"
+    }
+  }
+}

--- a/source/Sashimi.Tests/CommonTemplates/InlineJsonWithVariablesV0150.json
+++ b/source/Sashimi.Tests/CommonTemplates/InlineJsonWithVariablesV0150.json
@@ -1,0 +1,29 @@
+﻿{
+  "variable": {
+    "ami": {
+      "type": "string",
+      "description": "the AMI to use",
+      "default": "1234567890"
+    }
+  },
+  "output": {
+    "test": {
+      "value": "hi there"
+    },
+    "test2": {
+      "value": [
+        "hi there",
+        "hi again"
+      ]
+    },
+    "test3": {
+      "value": "${tomap({ a = \"hi\" })}"
+    },
+    "ami": {
+      "value": "${var.ami}"
+    },
+    "random": {
+      "value": "#{RandomNumber}"
+    }
+  }
+}

--- a/source/Sashimi.Tests/CommonTemplates/SingleVariable.json
+++ b/source/Sashimi.Tests/CommonTemplates/SingleVariable.json
@@ -1,0 +1,13 @@
+﻿{
+  "variable": {
+    "ami": {
+      "type": "string",
+      "description": "the AMI to use"
+    }
+  },
+  "output": {
+    "ami": {
+      "value": "${var.ami}"
+    }
+  }
+}

--- a/source/Sashimi.Tests/CommonTemplates/TemplateLoader.cs
+++ b/source/Sashimi.Tests/CommonTemplates/TemplateLoader.cs
@@ -1,0 +1,15 @@
+﻿using System.IO;
+using Octopus.Data;
+
+namespace Sashimi.Terraform.Tests.CommonTemplates
+{
+    public static class TemplateLoader
+    {
+        private const string TemplatesFolder = "CommonTemplates";
+
+        public static string LoadTextTemplate(string templateName)
+        {
+            return File.ReadAllText(Path.Combine(TemplatesFolder, templateName));
+        }
+    }
+}

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -25,6 +25,12 @@
     <None Update="**/*.tf*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="**/*.hcl">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="**/*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="**/*.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/source/Sashimi/TerraformSpecialVariables.cs
+++ b/source/Sashimi/TerraformSpecialVariables.cs
@@ -36,6 +36,7 @@ namespace Sashimi.Terraform
                 public const string AzureManagedAccount = "Octopus.Action.Terraform.AzureAccount";
                 public const string PlanOutput = "TerraformPlanOutput";
                 public const string PlanDetailedExitCode = "TerraformPlanDetailedExitCode";
+                public const string EnvironmentVariables = "Octopus.Action.Terraform.EnvVariables";
             }
 
             public static class Aws


### PR DESCRIPTION
This PR adds `Octopus.Action.Terraform.EnvVariables` Variable (key/value collection) that allows users to override the environment variables that we supply to the `CommandLineInvocation` and add their own. This is really neat if you want to use functionality not directly exposed in the UI/API.

Related PR will be raised in the Server repository, once this is merged. Changes are backwards compatible.