### PR TITLE
Bump terraform version for updated gpg keys

### DIFF
--- a/source/Calamari/Behaviours/ApplyBehaviour.cs
+++ b/source/Calamari/Behaviours/ApplyBehaviour.cs
@@ -35,7 +35,7 @@ namespace Calamari.Terraform.Behaviours
                                cli.TerraformVariableFiles,
                                cli.ActionParams);
 
-            // Attempt to get the outputs. This will fail if none are defined in versions prior to v0.11.8
+            // Attempt to get the outputs. This will fail if none are defined in versions prior to v0.11.15
             // Please note that we really don't want to log the following command output as it can contain sensitive variables etc. hence the IgnoreCommandOutput()
             if (cli.ExecuteCommand(out var result,
                                    false,

--- a/source/Calamari/TerraformCliExecutor.cs
+++ b/source/Calamari/TerraformCliExecutor.cs
@@ -31,7 +31,7 @@ namespace Calamari.Terraform
         Dictionary<string, string> defaultEnvironmentVariables;
         readonly Version version;
 
-        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.8"), true, NuGetVersion.Parse("0.15"), true);
+        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("0.15"), true);
 
         public TerraformCliExecutor(
             ILog log,

--- a/source/Sashimi.Tests/ActionHandlersFixture.cs
+++ b/source/Sashimi.Tests/ActionHandlersFixture.cs
@@ -231,7 +231,7 @@ namespace Sashimi.Terraform.Tests
         [Test]
         public void ExtraInitParametersAreSet()
         {
-            IgnoreIfVersionIsNotInRange("0.11.8", "0.15.0");
+            IgnoreIfVersionIsNotInRange("0.11.15", "0.15.0");
                 
             var additionalParams = "-var-file=\"backend.tfvars\"";
             ExecuteAndReturnLogOutput<TerraformPlanActionHandler>(_ =>
@@ -244,7 +244,7 @@ namespace Sashimi.Terraform.Tests
         [Test]
         public void AllowPluginDownloadsShouldBeDisabled()
         {
-            IgnoreIfVersionIsNotInRange("0.11.8", "0.15.0");
+            IgnoreIfVersionIsNotInRange("0.11.15", "0.15.0");
             
             ExecuteAndReturnLogOutput<TerraformPlanActionHandler>(
                                                                   _ =>
@@ -550,7 +550,7 @@ namespace Sashimi.Terraform.Tests
         [Test]
         public void InlineHclTemplateAndVariables()
         {
-            IgnoreIfVersionIsNotInRange("0.11.8", "0.15.0");
+            IgnoreIfVersionIsNotInRange("0.11.15", "0.15.0");
             
             const string variables =
                 "{\"stringvar\":\"default string\",\"images\":\"\",\"test2\":\"\",\"test3\":\"\",\"test4\":\"\"}";
@@ -643,7 +643,7 @@ output ""config-map-aws-auth"" {{
         [Test]
         public void InlineJsonTemplateAndVariables()
         {
-            IgnoreIfVersionIsNotInRange("0.11.8", "0.15.0");
+            IgnoreIfVersionIsNotInRange("0.11.15", "0.15.0");
             
             const string variables =
                 "{\"ami\":\"new ami value\"}";

--- a/source/Sashimi.Tests/BundledCliFixture.cs
+++ b/source/Sashimi.Tests/BundledCliFixture.cs
@@ -14,7 +14,7 @@ namespace Sashimi.Terraform.Tests
     [TestFixture]
     public class BundledCliFixture
     {
-        internal const string TerraformVersion = "0.11.8";
+        internal const string TerraformVersion = "0.11.15";
 
         //Note that the CLI package may not end up in the test build folder when running locally.
         [Test]

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Octopus.CoreParsers.Hcl" Version="1.1.2" />
-    <PackageReference Include="Octopus.Dependencies.TerraformCLI" Version="1.0.9" />
+    <PackageReference Include="Octopus.Dependencies.TerraformCLI" Version="1.0.10" />
     <PackageReference Include="Sashimi.Server.Contracts" Version="11.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Hashicorp have rotated their gpg keys due to a [vulnerability](https://discuss.hashicorp.com/t/hcsec-2021-12-codecov-security-event-and-hashicorp-gpg-key-exposure/23512) and backported the changes to 0.11.x as part of 0.11.15. This PR bumps our tooling version to `0.11.15` to follow suite, otherwise terraform will be unable to download newer versions of providers with an error such as:

```
Error installing provider "aws": openpgp: signature made by unknown entity.
```