### PR TITLE
Updates supported Terraform versions to include 1.0

### DIFF
--- a/source/Calamari/TerraformCliExecutor.cs
+++ b/source/Calamari/TerraformCliExecutor.cs
@@ -192,7 +192,7 @@ namespace Calamari.Terraform
                 if (!supportedVersionRange.Satisfies(new NuGetVersion(version)))
                 {
                     var messageCode = "Terraform-Configuration-UntestedTerraformCLIVersion";
-                    log.Warn($"Terraform steps are tested against versions {supportedVersionRange.MinVersion.ToNormalizedString()} to {supportedVersionRange.MaxVersion.ToNormalizedString()} of the Terraform CLI. Version {consoleOutput} of Terraform CLI has not been tested, however Terraform commands may work successfully with this version. Learn more about Terraform CLI versions at {log.FormatLink($"https://g.octopushq.com/Terraform#{messageCode.ToLower()}", messageCode)}");
+                    log.Warn($"Terraform steps are tested against versions {(supportedVersionRange.IsMinInclusive ? "> " : "")}{supportedVersionRange.MinVersion.ToNormalizedString()} to {(supportedVersionRange.IsMaxInclusive ? "" : "< ")}{supportedVersionRange.MaxVersion.ToNormalizedString()} of the Terraform CLI. Version {consoleOutput} of Terraform CLI has not been tested, however Terraform commands may work successfully with this version. Learn more about Terraform CLI versions at {log.FormatLink($"https://g.octopushq.com/Terraform#{messageCode.ToLower()}", messageCode)}");
                 }
             }
 

--- a/source/Calamari/TerraformCliExecutor.cs
+++ b/source/Calamari/TerraformCliExecutor.cs
@@ -31,7 +31,7 @@ namespace Calamari.Terraform
         Dictionary<string, string> defaultEnvironmentVariables;
         readonly Version version;
 
-        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("0.16"), false);
+        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("1.1"), false);
 
         public TerraformCliExecutor(
             ILog log,

--- a/source/Calamari/TerraformCliExecutor.cs
+++ b/source/Calamari/TerraformCliExecutor.cs
@@ -31,7 +31,7 @@ namespace Calamari.Terraform
         Dictionary<string, string> defaultEnvironmentVariables;
         readonly Version version;
 
-        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("1.1"), false);
+        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("0.16"), true);
 
         public TerraformCliExecutor(
             ILog log,

--- a/source/Calamari/TerraformCliExecutor.cs
+++ b/source/Calamari/TerraformCliExecutor.cs
@@ -31,7 +31,7 @@ namespace Calamari.Terraform
         Dictionary<string, string> defaultEnvironmentVariables;
         readonly Version version;
 
-        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("0.15"), true);
+        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("1.0"), true);
 
         public TerraformCliExecutor(
             ILog log,

--- a/source/Calamari/TerraformCliExecutor.cs
+++ b/source/Calamari/TerraformCliExecutor.cs
@@ -192,7 +192,7 @@ namespace Calamari.Terraform
                 if (!supportedVersionRange.Satisfies(new NuGetVersion(version)))
                 {
                     var messageCode = "Terraform-Configuration-UntestedTerraformCLIVersion";
-                    log.Warn($"{messageCode}: Terraform steps are tested against versions {supportedVersionRange} of the Terraform CLI. Version {consoleOutput} of Terraform CLI has not been tested, however Terraform commands may work successfully with this version. Learn more about Terraform CLI versions at {log.FormatLink($"https://g.octopushq.com/Terraform#{messageCode.ToLower()}", messageCode)}");
+                    log.Warn($"{messageCode}: Terraform steps are tested against versions {supportedVersionRange.MinVersion.ToNormalizedString()} to {supportedVersionRange.MaxVersion.ToNormalizedString()} of the Terraform CLI. Version {consoleOutput} of Terraform CLI has not been tested, however Terraform commands may work successfully with this version. Learn more about Terraform CLI versions at {log.FormatLink($"https://g.octopushq.com/Terraform#{messageCode.ToLower()}", messageCode)}");
                 }
             }
 

--- a/source/Calamari/TerraformCliExecutor.cs
+++ b/source/Calamari/TerraformCliExecutor.cs
@@ -31,7 +31,7 @@ namespace Calamari.Terraform
         Dictionary<string, string> defaultEnvironmentVariables;
         readonly Version version;
 
-        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("1.0"), true);
+        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("1.1"), false);
 
         public TerraformCliExecutor(
             ILog log,
@@ -190,7 +190,7 @@ namespace Calamari.Terraform
             else
             {
                 if (!supportedVersionRange.Satisfies(new NuGetVersion(version)))
-                    log.Warn($"Version {consoleOutput} of Terraform CLI is not supported. Supported version range is: {supportedVersionRange}");
+                    log.Warn($"Version {consoleOutput} of Terraform CLI is not supported. The supported version range is: {supportedVersionRange}. Terraform commands may work successfully however version {consoleOutput} is not tested.");
             }
 
             return version;

--- a/source/Calamari/TerraformCliExecutor.cs
+++ b/source/Calamari/TerraformCliExecutor.cs
@@ -31,7 +31,7 @@ namespace Calamari.Terraform
         Dictionary<string, string> defaultEnvironmentVariables;
         readonly Version version;
 
-        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("1.1"), false);
+        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("0.16"), false);
 
         public TerraformCliExecutor(
             ILog log,
@@ -192,7 +192,7 @@ namespace Calamari.Terraform
                 if (!supportedVersionRange.Satisfies(new NuGetVersion(version)))
                 {
                     var messageCode = "Terraform-Configuration-UntestedTerraformCLIVersion";
-                    log.Warn($"{messageCode}: Terraform steps are tested against versions {supportedVersionRange.MinVersion.ToNormalizedString()} to {supportedVersionRange.MaxVersion.ToNormalizedString()} of the Terraform CLI. Version {consoleOutput} of Terraform CLI has not been tested, however Terraform commands may work successfully with this version. Learn more about Terraform CLI versions at {log.FormatLink($"https://g.octopushq.com/Terraform#{messageCode.ToLower()}", messageCode)}");
+                    log.Warn($"Terraform steps are tested against versions {supportedVersionRange.MinVersion.ToNormalizedString()} to {supportedVersionRange.MaxVersion.ToNormalizedString()} of the Terraform CLI. Version {consoleOutput} of Terraform CLI has not been tested, however Terraform commands may work successfully with this version. Learn more about Terraform CLI versions at {log.FormatLink($"https://g.octopushq.com/Terraform#{messageCode.ToLower()}", messageCode)}");
                 }
             }
 

--- a/source/Calamari/TerraformCliExecutor.cs
+++ b/source/Calamari/TerraformCliExecutor.cs
@@ -192,7 +192,7 @@ namespace Calamari.Terraform
                 if (!supportedVersionRange.Satisfies(new NuGetVersion(version)))
                 {
                     var messageCode = "Terraform-Configuration-UntestedTerraformCLIVersion";
-                    log.Warn($"Terraform steps are tested against versions {(supportedVersionRange.IsMinInclusive ? "> " : "")}{supportedVersionRange.MinVersion.ToNormalizedString()} to {(supportedVersionRange.IsMaxInclusive ? "" : "< ")}{supportedVersionRange.MaxVersion.ToNormalizedString()} of the Terraform CLI. Version {consoleOutput} of Terraform CLI has not been tested, however Terraform commands may work successfully with this version. Learn more about Terraform CLI versions at {log.FormatLink($"https://g.octopushq.com/Terraform#{messageCode.ToLower()}", messageCode)}");
+                    log.Warn($"{log.FormatLink($"https://g.octopushq.com/Terraform#{messageCode.ToLower()}", messageCode)}: Terraform steps are tested against versions {(supportedVersionRange.IsMinInclusive ? "" : ">")}{supportedVersionRange.MinVersion.ToNormalizedString()} to {(supportedVersionRange.IsMaxInclusive ? "" : "<")}{supportedVersionRange.MaxVersion.ToNormalizedString()} of the Terraform CLI. Version {consoleOutput} of Terraform CLI has not been tested, however Terraform commands may work successfully with this version. Click the error code link for more information.");
                 }
             }
 

--- a/source/Calamari/TerraformCliExecutor.cs
+++ b/source/Calamari/TerraformCliExecutor.cs
@@ -31,7 +31,7 @@ namespace Calamari.Terraform
         Dictionary<string, string> defaultEnvironmentVariables;
         readonly Version version;
 
-        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("0.16"), true);
+        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("1.1"), false);
 
         public TerraformCliExecutor(
             ILog log,
@@ -160,7 +160,7 @@ namespace Calamari.Terraform
             var initParams = variables.Get(TerraformSpecialVariables.Action.Terraform.AdditionalInitParams);
             var allowPluginDownloads = variables.GetFlag(TerraformSpecialVariables.Action.Terraform.AllowPluginDownloads, true);
             string initCommand = $"init -no-color";
-            
+
             if (version.IsLessThan("0.15.0"))
                 initCommand += $" -get-plugins={allowPluginDownloads.ToString().ToLower()}";
 
@@ -190,7 +190,7 @@ namespace Calamari.Terraform
             else
             {
                 if (!supportedVersionRange.Satisfies(new NuGetVersion(version)))
-                    log.Warn($"Version {consoleOutput} of Terraform CLI is not supported. The supported version range is: {supportedVersionRange}. Terraform commands may work successfully however version {consoleOutput} is not tested.");
+                    log.Warn($"Version {consoleOutput} of Terraform CLI has not been tested and is not supported, however Terraform commands may work successfully with this version. The supported version range is: {supportedVersionRange}.");
             }
 
             return version;

--- a/source/Calamari/TerraformCliExecutor.cs
+++ b/source/Calamari/TerraformCliExecutor.cs
@@ -190,7 +190,10 @@ namespace Calamari.Terraform
             else
             {
                 if (!supportedVersionRange.Satisfies(new NuGetVersion(version)))
-                    log.Warn($"Version {consoleOutput} of Terraform CLI has not been tested and is not supported, however Terraform commands may work successfully with this version. The supported version range is: {supportedVersionRange}.");
+                {
+                    var messageCode = "Terraform-Configuration-UntestedTerraformCLIVersion";
+                    log.Warn($"{messageCode}: Terraform steps are tested against versions {supportedVersionRange} of the Terraform CLI. Version {consoleOutput} of Terraform CLI has not been tested, however Terraform commands may work successfully with this version. Learn more about Terraform CLI versions at {log.FormatLink($"https://g.octopushq.com/Terraform#{messageCode.ToLower()}", messageCode)}");
+                }
             }
 
             return version;

--- a/source/Sashimi.Tests/ActionHandlersFixture.cs
+++ b/source/Sashimi.Tests/ActionHandlersFixture.cs
@@ -28,7 +28,7 @@ using TestEnvironment = Sashimi.Tests.Shared.TestEnvironment;
 namespace Sashimi.Terraform.Tests
 {
     [TestFixture(BundledCliFixture.TerraformVersion)]
-    [TestFixture("0.15.0")]
+    [TestFixture("1.0.0")]
     public class ActionHandlersFixture
     {
         string? customTerraformExecutable;
@@ -100,7 +100,7 @@ namespace Sashimi.Terraform.Tests
         public async Task InstallTools()
         {
             ClearTestDirectories(); // pre-emptively clear test directories for better dev experience
-            
+
             static string GetTerraformFileName(string currentVersion)
             {
                 if (CalamariEnvironment.IsRunningOnNix)
@@ -185,7 +185,7 @@ namespace Sashimi.Terraform.Tests
         public void ExtraInitParametersAreSet()
         {
             IgnoreIfVersionIsNotInRange("0.11.15", "0.15.0");
-                
+
             var additionalParams = "-var-file=\"backend.tfvars\"";
             ExecuteAndReturnLogOutput<TerraformPlanActionHandler>(_ =>
                                                                       _.Variables.Add(TerraformSpecialVariables.Action.Terraform.AdditionalInitParams, additionalParams),
@@ -198,7 +198,7 @@ namespace Sashimi.Terraform.Tests
         public void AllowPluginDownloadsShouldBeDisabled()
         {
             IgnoreIfVersionIsNotInRange("0.11.15", "0.15.0");
-            
+
             ExecuteAndReturnLogOutput<TerraformPlanActionHandler>(
                                                                   _ =>
                                                                   {
@@ -504,7 +504,7 @@ namespace Sashimi.Terraform.Tests
         public void InlineHclTemplateAndVariables()
         {
             IgnoreIfVersionIsNotInRange("0.11.15", "0.15.0");
-            
+
             const string variables =
                 "{\"stringvar\":\"default string\",\"images\":\"\",\"test2\":\"\",\"test3\":\"\",\"test4\":\"\"}";
             const string template = @"variable stringvar {
@@ -564,12 +564,12 @@ output ""nestedmap"" {
                                                                        _.OutputVariables.ContainsKey("TerraformValueOutputs[nestedmap]").Should().BeTrue();
                                                                    });
         }
-        
+
         [Test]
         public void InlineHclTemplateAndVariablesV015()
         {
             IgnoreIfVersionIsNotInRange("0.15.0");
-                
+
             const string variables =
                 "{\"stringvar\":\"default string\",\"images\":\"\",\"test2\":\"\",\"test3\":\"\",\"test4\":\"\"}";
             const string template = @"variable stringvar {
@@ -672,12 +672,12 @@ output ""config-map-aws-auth"" {{
                                                                         .Be($"{expected.Replace("\r\n", "\n")}");
                                                                    });
         }
-        
+
         [Test]
         public void InlineJsonTemplateAndVariables()
         {
             IgnoreIfVersionIsNotInRange("0.11.15", "0.15.0");
-            
+
             const string variables =
                 "{\"ami\":\"new ami value\"}";
             const string template = @"{
@@ -729,12 +729,12 @@ output ""config-map-aws-auth"" {{
                                                                        _.OutputVariables["TerraformValueOutputs[random]"].Value.Should().Be(randomNumber);
                                                                    });
         }
-        
+
         [Test]
         public void InlineJsonTemplateAndVariablesV015()
         {
             IgnoreIfVersionIsNotInRange("0.15.0");
-            
+
             const string variables =
                 "{\"ami\":\"new ami value\"}";
             const string template = @"{
@@ -826,7 +826,7 @@ output ""config-map-aws-auth"" {{
         {
             var assertResult = assert ?? (_ => { });
 
-            var terraformFiles = Path.IsPathRooted(folderName) ? folderName : TestEnvironment.GetTestPath(folderName); 
+            var terraformFiles = Path.IsPathRooted(folderName) ? folderName : TestEnvironment.GetTestPath(folderName);
 
             var result = ActionHandlerTestBuilder.CreateAsync<Program>(commandType)
                                                                        .WithArrange(context =>
@@ -851,12 +851,12 @@ output ""config-map-aws-auth"" {{
             assertResult(result);
             return result;
         }
-        
+
         private void IgnoreIfVersionIsNotInRange(string minimumVersion, string? maximumVersion = null)
         {
             var _minimumVersion = new Version(minimumVersion);
             var _maximumVersion = new Version(maximumVersion ?? "999.0.0");
-            
+
             if (terraformCliVersionAsObject.CompareTo(_minimumVersion) < 0
                 || terraformCliVersionAsObject.CompareTo(_maximumVersion) >= 0)
             {

--- a/source/Sashimi.Tests/ActionHandlersFixture.cs
+++ b/source/Sashimi.Tests/ActionHandlersFixture.cs
@@ -860,7 +860,7 @@ output ""config-map-aws-auth"" {{
             if (terraformCliVersionAsObject.CompareTo(_minimumVersion) < 0
                 || terraformCliVersionAsObject.CompareTo(_maximumVersion) >= 0)
             {
-                Assert.Ignore();
+                Assert.Ignore($"Test ignored as terraform version is not between {_minimumVersion} and {_maximumVersion}");
             }
         }
     }


### PR DESCRIPTION
This PR updates the supported Terraform versions to include recently released version 1.0. Also updates the warning message to be more friendly and to include a link out to documentation.