### PR TITLE
Updates supported Terraform versions to include 1.0

### DIFF
--- a/source/Calamari/TerraformCliExecutor.cs
+++ b/source/Calamari/TerraformCliExecutor.cs
@@ -32,7 +32,7 @@ namespace Calamari.Terraform
         readonly Version version;
         readonly TemporaryDirectory disposableDirectory = TemporaryDirectory.Create();
 
-        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("0.16"), false);
+        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("1.1"), false);
 
         public TerraformCliExecutor(
             ILog log,
@@ -208,7 +208,10 @@ namespace Calamari.Terraform
             else
             {
                 if (!supportedVersionRange.Satisfies(new NuGetVersion(version)))
-                    log.Warn($"Version {consoleOutput} of Terraform CLI is not supported. Supported version range is: {supportedVersionRange}");
+                {
+                    var messageCode = "Terraform-Configuration-UntestedTerraformCLIVersion";
+                    log.Warn($"{log.FormatLink($"https://g.octopushq.com/Terraform#{messageCode.ToLower()}", messageCode)}: Terraform steps are tested against versions {(supportedVersionRange.IsMinInclusive ? "" : ">")}{supportedVersionRange.MinVersion.ToNormalizedString()} to {(supportedVersionRange.IsMaxInclusive ? "" : "<")}{supportedVersionRange.MaxVersion.ToNormalizedString()} of the Terraform CLI. Version {consoleOutput} of Terraform CLI has not been tested, however Terraform commands may work successfully with this version. Click the error code link for more information.");
+                }
             }
 
             return version;

--- a/source/Sashimi.Tests/ActionHandlersFixture.cs
+++ b/source/Sashimi.Tests/ActionHandlersFixture.cs
@@ -27,7 +27,7 @@ using TestEnvironment = Sashimi.Tests.Shared.TestEnvironment;
 namespace Sashimi.Terraform.Tests
 {
     [TestFixture(BundledCliFixture.TerraformVersion)]
-    [TestFixture("0.15.5")]
+    [TestFixture("1.0.0")]
     public class ActionHandlersFixture
     {
         string? customTerraformExecutable;
@@ -835,7 +835,7 @@ output ""config-map-aws-auth"" {{
             if (terraformCliVersionAsObject.CompareTo(minimumVersion) < 0
                 || terraformCliVersionAsObject.CompareTo(maximumVersion) >= 0)
             {
-                Assert.Ignore();
+                Assert.Ignore($"Test ignored as terraform version is not between {minimumVersion} and {maximumVersion}");
             }
         }
     }


### PR DESCRIPTION
This PR updates the supported Terraform versions to include recently released version 1.0. Also updates the warning message to be more friendly and to include a link out to documentation.

PR contains commits cherry-picked from https://github.com/OctopusDeploy/Sashimi.Terraform/pull/30.