### PR TITLE
Only show untested Terraform CLI version if needed

### DIFF
--- a/source/Calamari/Behaviours/PlanBehaviour.cs
+++ b/source/Calamari/Behaviours/PlanBehaviour.cs
@@ -42,8 +42,7 @@ namespace Calamari.Terraform.Behaviours
                                                        cli.ActionParams);
                 var resultCode = commandResult.ExitCode;
 
-                if (resultCode == 1)
-                    cli.VerifySuccess(commandResult);
+                cli.VerifySuccess(commandResult, r => r.ExitCode == 0 || r.ExitCode == 2);
 
                 log.Info(
                          $"Saving variable 'Octopus.Action[{deployment.Variables["Octopus.Action.StepName"]}].Output.{TerraformSpecialVariables.Action.Terraform.PlanDetailedExitCode}' with the detailed exit code of the plan, with value '{resultCode}'.");

--- a/source/Calamari/Behaviours/PlanBehaviour.cs
+++ b/source/Calamari/Behaviours/PlanBehaviour.cs
@@ -43,13 +43,7 @@ namespace Calamari.Terraform.Behaviours
                 var resultCode = commandResult.ExitCode;
 
                 if (resultCode == 1)
-                {
-                    // exit code of 1 indicates error, whereas 2 is not an error instead it is changes would be applied
-                    // Log untested version and verify success to throw out
-                    cli.LogUntestedVersionMessageIfNeeded(commandResult);
-                    commandResult.VerifySuccess();
-                }
-
+                    cli.VerifySuccess(commandResult);
 
                 log.Info(
                          $"Saving variable 'Octopus.Action[{deployment.Variables["Octopus.Action.StepName"]}].Output.{TerraformSpecialVariables.Action.Terraform.PlanDetailedExitCode}' with the detailed exit code of the plan, with value '{resultCode}'.");

--- a/source/Calamari/Behaviours/PlanBehaviour.cs
+++ b/source/Calamari/Behaviours/PlanBehaviour.cs
@@ -43,7 +43,13 @@ namespace Calamari.Terraform.Behaviours
                 var resultCode = commandResult.ExitCode;
 
                 if (resultCode == 1)
+                {
+                    // exit code of 1 indicates error, whereas 2 is not an error instead it is changes would be applied
+                    // Log untested version and verify success to throw out
+                    cli.LogUntestedVersionMessageIfNeeded(commandResult);
                     commandResult.VerifySuccess();
+                }
+
 
                 log.Info(
                          $"Saving variable 'Octopus.Action[{deployment.Variables["Octopus.Action.StepName"]}].Output.{TerraformSpecialVariables.Action.Terraform.PlanDetailedExitCode}' with the detailed exit code of the plan, with value '{resultCode}'.");

--- a/source/Calamari/TerraformCliExecutor.cs
+++ b/source/Calamari/TerraformCliExecutor.cs
@@ -32,7 +32,7 @@ namespace Calamari.Terraform
         readonly Version version;
         bool haveLoggedUntestedVersionInfoMessage = false;
 
-        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("1.1"), false);
+        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("1.0"), false);
 
         public TerraformCliExecutor(
             ILog log,
@@ -147,7 +147,7 @@ namespace Calamari.Terraform
                 {
                     log.Warn(message);
                 }
-                else if (!haveLoggedUntestedVersionInfoMessage) // Only want to log an info message once, not on every command
+                else
                 {
                     log.Info(message);
                     haveLoggedUntestedVersionInfoMessage = true;

--- a/source/Calamari/TerraformCliExecutor.cs
+++ b/source/Calamari/TerraformCliExecutor.cs
@@ -32,7 +32,7 @@ namespace Calamari.Terraform
         readonly Version version;
         bool haveLoggedUntestedVersionInfoMessage = false;
 
-        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("1.1"), false);
+        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("1.0"), false);
 
         public TerraformCliExecutor(
             ILog log,

--- a/source/Calamari/TerraformCliExecutor.cs
+++ b/source/Calamari/TerraformCliExecutor.cs
@@ -32,7 +32,7 @@ namespace Calamari.Terraform
         readonly Version version;
         bool haveLoggedUntestedVersionInfoMessage = false;
 
-        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("1.0"), false);
+        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("1.1"), false);
 
         public TerraformCliExecutor(
             ILog log,
@@ -147,7 +147,7 @@ namespace Calamari.Terraform
                 {
                     log.Warn(message);
                 }
-                else
+                else if (!haveLoggedUntestedVersionInfoMessage) // Only want to log an info message once, not on every command
                 {
                     log.Info(message);
                     haveLoggedUntestedVersionInfoMessage = true;

--- a/source/Calamari/TerraformCliExecutor.cs
+++ b/source/Calamari/TerraformCliExecutor.cs
@@ -32,7 +32,7 @@ namespace Calamari.Terraform
         readonly Version version;
         bool haveLoggedUntestedVersionInfoMessage = false;
 
-        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("1.0"), false);
+        readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("1.1"), false);
 
         public TerraformCliExecutor(
             ILog log,

--- a/source/Calamari/TerraformCliExecutor.cs
+++ b/source/Calamari/TerraformCliExecutor.cs
@@ -30,6 +30,7 @@ namespace Calamari.Terraform
         readonly string logPath;
         Dictionary<string, string> defaultEnvironmentVariables;
         readonly Version version;
+        bool haveLoggedUntestedVersionInfoMessage = false;
 
         readonly VersionRange supportedVersionRange = new VersionRange(NuGetVersion.Parse("0.11.15"), true, NuGetVersion.Parse("1.1"), false);
 
@@ -152,7 +153,27 @@ namespace Calamari.Terraform
 
             result = string.Join("\n", captureOutput.Infos);
 
+            LogUntestedVersionMessageIfNeeded(commandResult);
+
             return commandResult;
+        }
+
+        void LogUntestedVersionMessageIfNeeded(CommandResult commandResult)
+        {
+            if (this.version != null && !supportedVersionRange.Satisfies(new NuGetVersion(version)))
+            {
+                var messageCode = "Terraform-Configuration-UntestedTerraformCLIVersion";
+                var message = $"{log.FormatLink($"https://g.octopushq.com/Terraform#{messageCode.ToLower()}", messageCode)}: Terraform steps are tested against versions {(supportedVersionRange.IsMinInclusive ? "" : ">")}{supportedVersionRange.MinVersion.ToNormalizedString()} to {(supportedVersionRange.IsMaxInclusive ? "" : "<")}{supportedVersionRange.MaxVersion.ToNormalizedString()} of the Terraform CLI. Version {version} of Terraform CLI has not been tested, however Terraform commands may work successfully with this version. Click the error code link for more information.";
+                if (commandResult.ExitCode != 0)
+                {
+                    log.Warn(message);
+                }
+                else if (!haveLoggedUntestedVersionInfoMessage) // Only want to log an info message once, not on every command
+                {
+                    log.Info(message);
+                    haveLoggedUntestedVersionInfoMessage = true;
+                }
+            }
         }
 
         void InitializePlugins()
@@ -186,14 +207,6 @@ namespace Calamari.Terraform
             if (!Version.TryParse(consoleOutput, out var version))
             {
                 log.Warn($"Could not determine Terraform CLI version.");
-            }
-            else
-            {
-                if (!supportedVersionRange.Satisfies(new NuGetVersion(version)))
-                {
-                    var messageCode = "Terraform-Configuration-UntestedTerraformCLIVersion";
-                    log.Warn($"{log.FormatLink($"https://g.octopushq.com/Terraform#{messageCode.ToLower()}", messageCode)}: Terraform steps are tested against versions {(supportedVersionRange.IsMinInclusive ? "" : ">")}{supportedVersionRange.MinVersion.ToNormalizedString()} to {(supportedVersionRange.IsMaxInclusive ? "" : "<")}{supportedVersionRange.MaxVersion.ToNormalizedString()} of the Terraform CLI. Version {consoleOutput} of Terraform CLI has not been tested, however Terraform commands may work successfully with this version. Click the error code link for more information.");
-                }
             }
 
             return version;

--- a/source/Calamari/TerraformCliExecutor.cs
+++ b/source/Calamari/TerraformCliExecutor.cs
@@ -128,11 +128,11 @@ namespace Calamari.Terraform
         {
             LogUntestedVersionMessageIfNeeded(commandResult, isSuccess);
 
-            if (!isSuccess(commandResult))
+            if (isSuccess == null || !isSuccess(commandResult))
                 commandResult.VerifySuccess();
         }
 
-        void VerifySuccess(CommandResult commandResult)
+        public void VerifySuccess(CommandResult commandResult)
         {
             VerifySuccess(commandResult, r => r.ExitCode == 0);
         }
@@ -143,7 +143,7 @@ namespace Calamari.Terraform
             {
                 var messageCode = "Terraform-Configuration-UntestedTerraformCLIVersion";
                 var message = $"{log.FormatLink($"https://g.octopushq.com/Terraform#{messageCode.ToLower()}", messageCode)}: Terraform steps are tested against versions {(supportedVersionRange.IsMinInclusive ? "" : ">")}{supportedVersionRange.MinVersion.ToNormalizedString()} to {(supportedVersionRange.IsMaxInclusive ? "" : "<")}{supportedVersionRange.MaxVersion.ToNormalizedString()} of the Terraform CLI. Version {version} of Terraform CLI has not been tested, however Terraform commands may work successfully with this version. Click the error code link for more information.";
-                if (!isSuccess(commandResult))
+                if (isSuccess == null || !isSuccess(commandResult))
                 {
                     log.Warn(message);
                 }


### PR DESCRIPTION
This PR changes the warning messages around untested Terraform CLI versions so that:
- If the result of the call to the CLI is not success (exit code != 0) then a warning message is logged if the version is untested
- If the result of the call to the CLI is success (exit code == 0) then an information message is logged if the version is untested, but only the first time, subsequent successful commands will not log.

There is one caveat to the success/not success that exists within the Terraform CLI, a plan will produce an exit code of 2 if the plan indicates that changes will occur, this is treated the same as a success and an information message will be logged if the version is untested.