### PR TITLE
Bump to `Calamari.Common@19.4.7`

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -17,8 +17,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.4.34" />
-    <PackageReference Include="Calamari.CloudAccounts" Version="19.2.0" />
-    <PackageReference Include="Calamari.Common" Version="19.2.0" />
+    <PackageReference Include="Calamari.CloudAccounts" Version="19.4.7" />
+    <PackageReference Include="Calamari.Common" Version="19.4.7" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Extensibility" Version="14.1.0" />
     <PackageReference Include="Octopus.Server.Extensibility.Tests" Version="10.0.1" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="11.0.0" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="13.3.1" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 


### PR DESCRIPTION
# Overview

This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.2.

Change: OctopusDeploy/Calamari#754

Issue: OctopusDeploy/Issues#6941

# Note

Due to OctopusDeploy/Calamari#757, `Calamari.CloudAccount` was bumped to `19.4.7` this is a noop bump for `Calamari.Common`.