### PR TITLE
Allow plan operations to export JSON

### DIFF
--- a/source/Calamari.Tests/TerraformPlanVariableFixture.cs
+++ b/source/Calamari.Tests/TerraformPlanVariableFixture.cs
@@ -48,7 +48,7 @@ namespace Calamari.Terraform.Tests
 
             for (var index = 0; index < splitOutput.Length; ++index)
             {
-                outputVars[$"TerraformPlanJsonLine{index}"].ShouldBe(splitOutput[index]);
+                outputVars[$"TerraformPlanLine[{index}].JSON"].ShouldBe(splitOutput[index]);
             }
 
             outputVars[TerraformSpecialVariables.Action.Terraform.PlanJsonChangesAdd].ShouldBe("0");

--- a/source/Calamari.Tests/TerraformPlanVariableFixture.cs
+++ b/source/Calamari.Tests/TerraformPlanVariableFixture.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Calamari.Common.Commands;
+using Calamari.Common.Features.Processes;
+using Calamari.Common.Plumbing.FileSystem;
+using Calamari.Common.Plumbing.Logging;
+using Calamari.Common.Plumbing.Variables;
+using Calamari.Terraform.Behaviours;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Calamari.Terraform.Tests
+{
+    public class TerraformPlanVariableFixture
+    {
+        const string JsonPlanOutput = @"{""@level"":""info"",""@message"":""Terraform 1.0.4"",""@module"":""terraform.ui"",""@timestamp"":""2021-08-24T07:29:27.798620+10:00"",""terraform"":""1.0.4"",""type"":""version"",""ui"":""0.1.0""}
+{""@level"":""info"",""@message"":""Plan: 0 to add, 0 to change, 0 to destroy."",""@module"":""terraform.ui"",""@timestamp"":""2021-08-24T07:29:27.884954+10:00"",""changes"":{""add"":0,""change"":0,""remove"":0,""operation"":""plan""},""type"":""change_summary""}";
+
+        ILog log;
+        ICalamariFileSystem calamariFileSystem;
+        ICommandLineRunner commandLineRunner;
+        RunningDeployment runningDeployment;
+        IVariables variables;
+
+        readonly IDictionary<string, string> outputVars = new Dictionary<string, string>();
+
+        [SetUp]
+        public void SetUp()
+        {
+            log = Substitute.For<ILog>();
+            log.When(x => x.SetOutputVariable(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IVariables>()))
+               .Do(x => outputVars.Add(x.ArgAt<string>(0), x.ArgAt<string>(1)));
+
+            calamariFileSystem = Substitute.For<ICalamariFileSystem>();
+            commandLineRunner = Substitute.For<ICommandLineRunner>();
+            variables = Substitute.For<IVariables>();
+            runningDeployment = Substitute.For<RunningDeployment>(variables);
+        }
+
+        [Test]
+        public void TestVariablesAreCaptured()
+        { 
+            var splitOutput = Regex.Split(JsonPlanOutput, PlanBehaviour.LineEndingRE);
+            new PlanBehaviour(log, calamariFileSystem, commandLineRunner).CaptureJsonOutput(runningDeployment, JsonPlanOutput);
+
+            for (var index = 0; index < splitOutput.Length; ++index)
+            {
+                outputVars[$"PlanJsonLine{index}"].ShouldBe(splitOutput[index]);
+            }
+
+            outputVars[TerraformSpecialVariables.Action.Terraform.PlanJsonChangesAdd].ShouldBe("0");
+            outputVars[TerraformSpecialVariables.Action.Terraform.PlanJsonChangesRemove].ShouldBe("0");
+            outputVars[TerraformSpecialVariables.Action.Terraform.PlanJsonChangesChange].ShouldBe("0");
+        }
+    }
+}

--- a/source/Calamari.Tests/TerraformPlanVariableFixture.cs
+++ b/source/Calamari.Tests/TerraformPlanVariableFixture.cs
@@ -48,7 +48,7 @@ namespace Calamari.Terraform.Tests
 
             for (var index = 0; index < splitOutput.Length; ++index)
             {
-                outputVars[$"PlanJsonLine{index}"].ShouldBe(splitOutput[index]);
+                outputVars[$"TerraformPlanJsonLine{index}"].ShouldBe(splitOutput[index]);
             }
 
             outputVars[TerraformSpecialVariables.Action.Terraform.PlanJsonChangesAdd].ShouldBe("0");

--- a/source/Calamari.Tests/TerraformPlanVariableFixture.cs
+++ b/source/Calamari.Tests/TerraformPlanVariableFixture.cs
@@ -36,13 +36,23 @@ namespace Calamari.Terraform.Tests
 
             calamariFileSystem = Substitute.For<ICalamariFileSystem>();
             commandLineRunner = Substitute.For<ICommandLineRunner>();
-            variables = Substitute.For<IVariables>();
+            variables = new CalamariVariables();
+            variables.Set(TerraformSpecialVariables.Action.Terraform.PlanJsonOutput, "True");
             runningDeployment = Substitute.For<RunningDeployment>(variables);
+        }
+
+        [TestCase("0.11", "")]
+        [TestCase("0.11.5", "")]
+        [TestCase("0.12", "--json")]
+        [TestCase("1.0", "--json")]
+        public void EnsurePlanOnlyWorksForTwelveAndAbove(string version, string expected)
+        {
+            new PlanBehaviour(log, calamariFileSystem, commandLineRunner).GetOutputParameter(runningDeployment, new Version(version)).ShouldBe(expected);
         }
 
         [Test]
         public void TestVariablesAreCaptured()
-        { 
+        {
             var splitOutput = Regex.Split(JsonPlanOutput, PlanBehaviour.LineEndingRE);
             new PlanBehaviour(log, calamariFileSystem, commandLineRunner).CaptureJsonOutput(runningDeployment, JsonPlanOutput);
 

--- a/source/Calamari/Behaviours/PlanBehaviour.cs
+++ b/source/Calamari/Behaviours/PlanBehaviour.cs
@@ -50,7 +50,6 @@ namespace Calamari.Terraform.Behaviours
                                                        "plan",
                                                        "-no-color",
                                                        "-detailed-exitcode",
-                                                       "--json",
                                                        GetOutputParameter(deployment),
                                                        GetExtraParameter,
                                                        cli.TerraformVariableFiles,

--- a/source/Calamari/Behaviours/PlanBehaviour.cs
+++ b/source/Calamari/Behaviours/PlanBehaviour.cs
@@ -26,7 +26,7 @@ namespace Calamari.Terraform.Behaviours
             this.commandLineRunner = commandLineRunner;
         }
 
-        protected virtual string GetExtraParameter => "";
+        protected virtual string ExtraParameter => "";
 
         bool IsUsingPlanJSON(RunningDeployment deployment)
         {
@@ -51,7 +51,7 @@ namespace Calamari.Terraform.Behaviours
                                                        "-no-color",
                                                        "-detailed-exitcode",
                                                        GetOutputParameter(deployment),
-                                                       GetExtraParameter,
+                                                       ExtraParameter,
                                                        cli.TerraformVariableFiles,
                                                        cli.ActionParams);
                 var resultCode = commandResult.ExitCode;

--- a/source/Calamari/Behaviours/PlanBehaviour.cs
+++ b/source/Calamari/Behaviours/PlanBehaviour.cs
@@ -35,7 +35,7 @@ namespace Calamari.Terraform.Behaviours
             return deployment.Variables.GetFlag(TerraformSpecialVariables.Action.Terraform.PlanJsonOutput);
         }
 
-        string GetOutputParameter(RunningDeployment deployment, Version version)
+        public string GetOutputParameter(RunningDeployment deployment, Version version)
         {
             if (version.IsLessThan(TerraformPlanJsonMinVersion))
             {

--- a/source/Calamari/Behaviours/PlanBehaviour.cs
+++ b/source/Calamari/Behaviours/PlanBehaviour.cs
@@ -84,7 +84,7 @@ namespace Calamari.Terraform.Behaviours
             var lines = Regex.Split(results, LineEndingRE);
             for (var index = 0; index < lines.Length; ++index)
             {
-                var variableName = $"TerraformPlanJsonLine{index}";
+                var variableName = $"TerraformPlanLine[{index}].JSON";
 
                 log.Info(
                          $"Saving variable 'Octopus.Action[{deployment.Variables["Octopus.Action.StepName"]}].Output.{variableName}' with the details of the plan");

--- a/source/Calamari/Behaviours/PlanBehaviour.cs
+++ b/source/Calamari/Behaviours/PlanBehaviour.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Calamari.Common.Commands;
@@ -37,8 +36,6 @@ namespace Calamari.Terraform.Behaviours
 
         protected override Task Execute(RunningDeployment deployment, Dictionary<string, string> environmentVariables)
         {
-            var jsonOutput = IsUsingPlanJSON(deployment);
-
             string results;
             using (var cli = new TerraformCliExecutor(log,
                                                       fileSystem,
@@ -63,7 +60,7 @@ namespace Calamari.Terraform.Behaviours
                 log.SetOutputVariable(TerraformSpecialVariables.Action.Terraform.PlanDetailedExitCode, resultCode.ToString(), deployment.Variables);
             }
 
-            if (jsonOutput)
+            if (IsUsingPlanJSON(deployment))
             {
                 CaptureJsonOutput(deployment, results);
             }

--- a/source/Calamari/Behaviours/PlanBehaviour.cs
+++ b/source/Calamari/Behaviours/PlanBehaviour.cs
@@ -96,9 +96,12 @@ namespace Calamari.Terraform.Behaviours
 
         void CaptureChangeSummary(RunningDeployment deployment, string line)
         {
-            var parsed = JObject.Parse(line);
-            if (parsed["type"].ToString() == "change_summary")
+            try
             {
+                var parsed = JObject.Parse(line);
+                if (parsed["type"].ToString() != "change_summary")
+                    return;
+
                 log.Info(
                          $"Saving variable 'Octopus.Action[{deployment.Variables["Octopus.Action.StepName"]}].Output.{TerraformSpecialVariables.Action.Terraform.PlanJsonChangesAdd}' with the the number of added resources in the plan");
                 log.SetOutputVariable(TerraformSpecialVariables.Action.Terraform.PlanJsonChangesAdd, parsed["changes"]?["add"]?.ToString() ?? "", deployment.Variables);
@@ -110,6 +113,10 @@ namespace Calamari.Terraform.Behaviours
                 log.Info(
                          $"Saving variable 'Octopus.Action[{deployment.Variables["Octopus.Action.StepName"]}].Output.{TerraformSpecialVariables.Action.Terraform.PlanJsonChangesChange}' with the the number of changed resources in the plan");
                 log.SetOutputVariable(TerraformSpecialVariables.Action.Terraform.PlanJsonChangesChange, parsed["changes"]?["change"]?.ToString() ?? "", deployment.Variables);
+            }
+            catch
+            {
+                log.Warn("Terraform output invalid JSON in the line: " + line);
             }
         }
     }

--- a/source/Calamari/Behaviours/PlanBehaviour.cs
+++ b/source/Calamari/Behaviours/PlanBehaviour.cs
@@ -79,7 +79,7 @@ namespace Calamari.Terraform.Behaviours
             log.SetOutputVariable(TerraformSpecialVariables.Action.Terraform.PlanOutput, results, deployment.Variables);
         }
 
-               public void CaptureJsonOutput(RunningDeployment deployment, string results)
+        public void CaptureJsonOutput(RunningDeployment deployment, string results)
         {
             var lines = Regex.Split(results, LineEndingRE);
             for (var index = 0; index < lines.Length; ++index)

--- a/source/Calamari/Behaviours/PlanBehaviour.cs
+++ b/source/Calamari/Behaviours/PlanBehaviour.cs
@@ -87,7 +87,7 @@ namespace Calamari.Terraform.Behaviours
             var lines = Regex.Split(results, LineEndingRE);
             for (var index = 0; index < lines.Length; ++index)
             {
-                var variableName = $"PlanJsonLine{index}";
+                var variableName = $"TerraformPlanJsonLine{index}";
                     
                 log.Info(
                          $"Saving variable 'Octopus.Action[{deployment.Variables["Octopus.Action.StepName"]}].Output.{variableName}' with the details of the plan");

--- a/source/Calamari/Behaviours/PlanBehaviour.cs
+++ b/source/Calamari/Behaviours/PlanBehaviour.cs
@@ -1,16 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Calamari.Common.Commands;
 using Calamari.Common.Features.Processes;
 using Calamari.Common.Plumbing.FileSystem;
 using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Pipeline;
+using Newtonsoft.Json.Linq;
 
 namespace Calamari.Terraform.Behaviours
 {
-    class PlanBehaviour : TerraformDeployBehaviour
+    public class PlanBehaviour : TerraformDeployBehaviour
     {
+        public const string LineEndingRE = "\r\n?|\n";
         readonly ICalamariFileSystem fileSystem;
         readonly ICommandLineRunner commandLineRunner;
 
@@ -26,6 +30,8 @@ namespace Calamari.Terraform.Behaviours
 
         protected override Task Execute(RunningDeployment deployment, Dictionary<string, string> environmentVariables)
         {
+            var jsonOutput = deployment.Variables.GetFlag(TerraformSpecialVariables.Action.Terraform.PlanJsonOutput);
+            
             string results;
             using (var cli = new TerraformCliExecutor(log,
                                                       fileSystem,
@@ -33,13 +39,28 @@ namespace Calamari.Terraform.Behaviours
                                                       deployment,
                                                       environmentVariables))
             {
-                var commandResult = cli.ExecuteCommand(out results,
-                                                       "plan",
-                                                       "-no-color",
-                                                       "-detailed-exitcode",
-                                                       ExtraParameter,
-                                                       cli.TerraformVariableFiles,
-                                                       cli.ActionParams);
+                var arguments = jsonOutput
+                    ? new[]
+                    {
+                        "plan",
+                        "-no-color",
+                        "-detailed-exitcode",
+                        "--json",
+                        ExtraParameter,
+                        cli.TerraformVariableFiles,
+                        cli.ActionParams
+                    }
+                    : new[]
+                    {
+                        "plan",
+                        "-no-color",
+                        "-detailed-exitcode",
+                        ExtraParameter,
+                        cli.TerraformVariableFiles,
+                        cli.ActionParams
+                    };
+
+                var commandResult = cli.ExecuteCommand(out results, arguments);
                 var resultCode = commandResult.ExitCode;
 
                 cli.VerifySuccess(commandResult, r => r.ExitCode == 0 || r.ExitCode == 2);
@@ -49,11 +70,58 @@ namespace Calamari.Terraform.Behaviours
                 log.SetOutputVariable(TerraformSpecialVariables.Action.Terraform.PlanDetailedExitCode, resultCode.ToString(), deployment.Variables);
             }
 
+            if (jsonOutput)
+            {
+                CaptureJsonOutput(deployment, results);
+            }
+            else
+            {
+                CapturePlainTextOutput(deployment, results);
+            }
+            
+            return this.CompletedTask();
+        }
+
+        public void CaptureJsonOutput(RunningDeployment deployment, string results)
+        {
+            var lines = Regex.Split(results, LineEndingRE);
+            for (var index = 0; index < lines.Length; ++index)
+            {
+                var variableName = $"PlanJsonLine{index}";
+                    
+                log.Info(
+                         $"Saving variable 'Octopus.Action[{deployment.Variables["Octopus.Action.StepName"]}].Output.{variableName}' with the details of the plan");
+                log.SetOutputVariable(variableName, lines[index], deployment.Variables);
+
+                CaptureChangeSummary(deployment, lines[index]);
+            }
+        }
+
+        void CaptureChangeSummary(RunningDeployment deployment, string line)
+        {
+            var parsed = JObject.Parse(line);
+            if (parsed["type"].ToString() == "change_summary")
+            {
+                log.Info(
+                         $"Saving variable 'Octopus.Action[{deployment.Variables["Octopus.Action.StepName"]}].Output.{TerraformSpecialVariables.Action.Terraform.PlanJsonChangesAdd}' with the the number of added resources in the plan");
+                log.SetOutputVariable(TerraformSpecialVariables.Action.Terraform.PlanJsonChangesAdd, parsed["changes"]?["add"]?.ToString() ?? "", deployment.Variables);
+                
+                log.Info(
+                         $"Saving variable 'Octopus.Action[{deployment.Variables["Octopus.Action.StepName"]}].Output.{TerraformSpecialVariables.Action.Terraform.PlanJsonChangesRemove}' with the the number of removed resources in the plan");
+                log.SetOutputVariable(TerraformSpecialVariables.Action.Terraform.PlanJsonChangesRemove, parsed["changes"]?["remove"]?.ToString() ?? "", deployment.Variables);
+                
+                log.Info(
+                         $"Saving variable 'Octopus.Action[{deployment.Variables["Octopus.Action.StepName"]}].Output.{TerraformSpecialVariables.Action.Terraform.PlanJsonChangesChange}' with the the number of changed resources in the plan");
+                log.SetOutputVariable(TerraformSpecialVariables.Action.Terraform.PlanJsonChangesChange, parsed["changes"]?["change"]?.ToString() ?? "", deployment.Variables);
+            }
+        }
+
+        void CapturePlainTextOutput(RunningDeployment deployment, string results)
+        {
             log.Info(
                      $"Saving variable 'Octopus.Action[{deployment.Variables["Octopus.Action.StepName"]}].Output.{TerraformSpecialVariables.Action.Terraform.PlanOutput}' with the details of the plan");
             log.SetOutputVariable(TerraformSpecialVariables.Action.Terraform.PlanOutput, results, deployment.Variables);
 
-            return this.CompletedTask();
         }
     }
 }

--- a/source/Calamari/Behaviours/TerraformDeployBehaviour.cs
+++ b/source/Calamari/Behaviours/TerraformDeployBehaviour.cs
@@ -12,7 +12,7 @@ using Newtonsoft.Json;
 
 namespace Calamari.Terraform.Behaviours
 {
-    abstract class TerraformDeployBehaviour : IDeployBehaviour
+    public abstract class TerraformDeployBehaviour : IDeployBehaviour
     {
         protected readonly ILog log;
 

--- a/source/Calamari/TerraformSpecialVariables.cs
+++ b/source/Calamari/TerraformSpecialVariables.cs
@@ -26,9 +26,9 @@ namespace Calamari.Terraform
                 public const string PlanDetailedExitCode = "TerraformPlanDetailedExitCode";
                 public const string EnvironmentVariables = "Octopus.Action.Terraform.EnvVariables";
                 public const string PlanJsonOutput = "Octopus.Action.Terraform.PlanJsonOutput";
-                public const string PlanJsonChangesAdd = "TerraformPlanJsonChangesAdd";
-                public const string PlanJsonChangesChange = "TerraformPlanJsonChangesChange";
-                public const string PlanJsonChangesRemove = "TerraformPlanJsonChangesRemove";
+                public const string PlanJsonChangesAdd = "TerraformPlanJsonAdd";
+                public const string PlanJsonChangesChange = "TerraformPlanJsonChange";
+                public const string PlanJsonChangesRemove = "TerraformPlanJsonRemove";
             }
         }
     }

--- a/source/Calamari/TerraformSpecialVariables.cs
+++ b/source/Calamari/TerraformSpecialVariables.cs
@@ -25,6 +25,10 @@ namespace Calamari.Terraform
                 public const string PlanOutput = "TerraformPlanOutput";
                 public const string PlanDetailedExitCode = "TerraformPlanDetailedExitCode";
                 public const string EnvironmentVariables = "Octopus.Action.Terraform.EnvVariables";
+                public const string PlanJsonOutput = "Octopus.Action.Terraform.PlanJsonOutput";
+                public const string PlanJsonChangesAdd = "PlanJsonChangesAdd";
+                public const string PlanJsonChangesChange = "PlanJsonChangesChange";
+                public const string PlanJsonChangesRemove = "PlanJsonChangesRemove";
             }
         }
     }

--- a/source/Calamari/TerraformSpecialVariables.cs
+++ b/source/Calamari/TerraformSpecialVariables.cs
@@ -26,9 +26,9 @@ namespace Calamari.Terraform
                 public const string PlanDetailedExitCode = "TerraformPlanDetailedExitCode";
                 public const string EnvironmentVariables = "Octopus.Action.Terraform.EnvVariables";
                 public const string PlanJsonOutput = "Octopus.Action.Terraform.PlanJsonOutput";
-                public const string PlanJsonChangesAdd = "PlanJsonChangesAdd";
-                public const string PlanJsonChangesChange = "PlanJsonChangesChange";
-                public const string PlanJsonChangesRemove = "PlanJsonChangesRemove";
+                public const string PlanJsonChangesAdd = "TerraformPlanJsonChangesAdd";
+                public const string PlanJsonChangesChange = "TerraformPlanJsonChangesChange";
+                public const string PlanJsonChangesRemove = "TerraformPlanJsonChangesRemove";
             }
         }
     }


### PR DESCRIPTION
This PR allows the Terraform plan operations to export the results as JSON and capture the JSON blobs as output variables.

New tests have been added to verify the JSON variable extraction process.