### PR TITLE
support GOOGLE_BACKEND_CREDENTIALS in Terraform steps using GCP accounts

### DIFF
--- a/source/Calamari/Behaviours/TerraformDeployBehaviour.cs
+++ b/source/Calamari/Behaviours/TerraformDeployBehaviour.cs
@@ -79,7 +79,8 @@ namespace Calamari.Terraform.Behaviours
                 var bytes = Convert.FromBase64String(keyFile);
                 var json = Encoding.UTF8.GetString(bytes);
                 googleCloudEnvironmentVariables.Add("GOOGLE_CLOUD_KEYFILE_JSON", json);
-                Log.Verbose($"A JSON key has been set to GOOGLE_CLOUD_KEYFILE_JSON environment variable");
+                googleCloudEnvironmentVariables.Add("GOOGLE_BACKEND_CREDENTIALS", json);
+                Log.Verbose($"A JSON key has been set to GOOGLE_CLOUD_KEYFILE_JSON and GOOGLE_BACKEND_CREDENTIALS environment variables");
             }
 
             var impersonateServiceAccount = variables.GetFlag("Octopus.Action.GoogleCloud.ImpersonateServiceAccount");


### PR DESCRIPTION
# Background

Resolve https://github.com/OctopusDeploy/Issues/issues/7201

Teams using the Terraform step template with GCP accounts are currently unable to use GCS as a Terraform backend without specifying credentials using Octopus variables and filters (see Workaround) or setting the environment variables themselves.

Workaround: Setting the credentials directly in the Terraform template is possible but requires some knowledge of the account variables and filters that are not intuitive to all users.

# Solution

Set either the GOOGLE_BACKEND_CREDENTIALS or GOOGLE_CREDENTIALS environment variable in the same manner that we set GOOGLE_CLOUD_KEYFILE_JSON on Terraform steps.

# Review
Quality
