### PR TITLE
Bumps Calamari.* to 19.4.10 and Sashimi.* to 14.0.3 (Server 2021.2 Stream)

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -17,8 +17,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.4.34" />
-    <PackageReference Include="Calamari.CloudAccounts" Version="19.4.7" />
-    <PackageReference Include="Calamari.Common" Version="19.4.7" />
+    <PackageReference Include="Calamari.CloudAccounts" Version="19.4.10" />
+    <PackageReference Include="Calamari.Common" Version="19.4.10" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Extensibility" Version="14.1.0" />
     <PackageReference Include="Octopus.Server.Extensibility.Tests" Version="10.0.1" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="14.0.1" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="14.0.3" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Octopus.CoreParsers.Hcl" Version="1.1.2" />
     <PackageReference Include="Octopus.Dependencies.TerraformCLI" Version="1.0.10" />
     <PackageReference Include="Octopus.Server.Extensibility" Version="14.1.0" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="14.0.1" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="14.0.3" />
   </ItemGroup>
 
   <Target Name="GetPackageFiles" AfterTargets="ResolveReferences" DependsOnTargets="RunResolvePackageDependencies">


### PR DESCRIPTION
# Overview
This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.2.

Upstream changes:
* OctopusDeploy/Calamari#808
* OctopusDeploy/Sashimi#133

To fix Issues:
* OctopusDeploy/Issues#6794
* OctopusDeploy/Issues#7177