### PR TITLE
Bumps Calamari.* to 20.4.2 and Sashimi.* to 14.1.3

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -17,8 +17,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.4.34" />
-    <PackageReference Include="Calamari.CloudAccounts" Version="20.3.6" />
-    <PackageReference Include="Calamari.Common" Version="20.3.6" />
+    <PackageReference Include="Calamari.CloudAccounts" Version="20.4.2" />
+    <PackageReference Include="Calamari.Common" Version="20.4.2" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -16,9 +16,9 @@
     <PackageReference Include="Assent" Version="1.6.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="14.1.0" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="14.3.2" />
     <PackageReference Include="Octopus.Server.Extensibility.Tests" Version="10.0.1" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="14.0.1" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="14.1.3" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Octopus.Server.Extensibility" Version="14.3.2" />
-    <PackageReference Include="Octopus.Server.Extensibility.Tests" Version="10.0.1" />
+    <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.3.3" />
     <PackageReference Include="Sashimi.Tests.Shared" Version="14.1.3" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>

--- a/source/Sashimi/ActionHandler/TerraformActionHandler.cs
+++ b/source/Sashimi/ActionHandler/TerraformActionHandler.cs
@@ -96,11 +96,10 @@ namespace Sashimi.Terraform.ActionHandler
 
         static Dictionary<string, string> GetEnvironmentVariableArgs(IActionAndTargetScopedVariables variables)
         {
-            var rawJson = variables.Get(TerraformSpecialVariables.Action.Terraform.EnvironmentVariables);
-            if (string.IsNullOrEmpty(rawJson))
-                return new Dictionary<string, string>();
+            var rawJson = variables.Get(TerraformSpecialVariables.Action.Terraform.EnvironmentVariables) ?? "";
 
-            return JsonConvert.DeserializeObject<Dictionary<string, string>>(rawJson);
+            return JsonConvert.DeserializeObject<Dictionary<string, string>>(rawJson) 
+                ?? new Dictionary<string, string>();
         }
     }
 }

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -26,8 +26,8 @@
   <ItemGroup>
     <PackageReference Include="Octopus.CoreParsers.Hcl" Version="1.1.2" />
     <PackageReference Include="Octopus.Dependencies.TerraformCLI" Version="1.0.10" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="14.1.0" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="14.0.1" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="14.3.2" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="14.1.3" />
   </ItemGroup>
 
   <Target Name="GetPackageFiles" AfterTargets="ResolveReferences" DependsOnTargets="RunResolvePackageDependencies">


### PR DESCRIPTION
# Overview
This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.3

Upstream changes:
* OctopusDeploy/Calamari#815
* OctopusDeploy/Sashimi#134

Issues:
* OctopusDeploy/Issues/issues/6794
* OctopusDeploy/Issues/issues/7177